### PR TITLE
Move experience to component

### DIFF
--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,16 +1,18 @@
 package work.fking.masteringmixology;
 
 public enum PotionComponent {
-    AGA('A', "00e676"),
-    LYE('L', "e91e63"),
-    MOX('M', "03a9f4");
+    AGA('A', "00e676", 85),
+    LYE('L', "e91e63", 45),
+    MOX('M', "03a9f4", 125);
 
     private final char character;
     private final String color;
+    private final int experience;
 
-    PotionComponent(char character, String color) {
+    PotionComponent(char character, String color, int experience) {
         this.character = character;
         this.color = color;
+        this.experience = experience;
     }
 
     public char character() {
@@ -19,5 +21,9 @@ public enum PotionComponent {
 
     public String color() {
         return color;
+    }
+
+    public int experience() {
+        return experience;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,9 +1,9 @@
 package work.fking.masteringmixology;
 
 public enum PotionComponent {
-    AGA('A', "00e676", 85),
-    LYE('L', "e91e63", 45),
-    MOX('M', "03a9f4", 125);
+    AGA('A', "00e676", 850),
+    LYE('L', "e91e63", 1250),
+    MOX('M', "03a9f4", 450);
 
     private final char character;
     private final String color;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -5,16 +5,16 @@ import java.util.Arrays;
 import static work.fking.masteringmixology.PotionComponent.*;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(60, 1350, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(60, 1750, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(60, 2150, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(76, 2550, AGA, AGA, AGA),
-    AZURE_AURA_MIX(68, 2150, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(72, 2950, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(86, 3750, LYE, LYE, LYE),
-    MEGALITE_LIQUID(80, 2950, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(84, 3350, AGA, LYE, LYE),
-    MIXALOT(64, 2550, MOX, AGA, LYE);
+    MAMMOTH_MIGHT_MIX(60, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(60, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(60, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(76, AGA, AGA, AGA),
+    AZURE_AURA_MIX(68, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(72, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(86, LYE, LYE, LYE),
+    MEGALITE_LIQUID(80, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(84, AGA, LYE, LYE),
+    MIXALOT(64, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
 
@@ -23,10 +23,10 @@ public enum PotionType {
     private final int experience;
     private final PotionComponent[] components;
 
-    PotionType(int levelReq, int experience, PotionComponent... components) {
+    PotionType(int levelReq, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
         this.levelReq = levelReq;
-        this.experience = experience;
+        this.experience = Arrays.stream(components).mapToInt(PotionComponent::experience).sum();
         this.components = components;
     }
 


### PR DESCRIPTION
Instead of setting the exp in the PotionType, we can set it in the components and calculate the experience in the type based on the components.
This means if exp rates are changed later we can more easily update it.

Also changes the experience numbers to be 10x less, not sure why they were so high