### PR TITLE
Include modifier exp when evaluating best exp

### DIFF
--- a/src/main/java/work/fking/masteringmixology/PotionModifier.java
+++ b/src/main/java/work/fking/masteringmixology/PotionModifier.java
@@ -1,16 +1,21 @@
 package work.fking.masteringmixology;
 
 public enum PotionModifier {
-    HOMOGENOUS(AlchemyObject.AGITATOR),
-    CONCENTRATED(AlchemyObject.RETORT),
-    CRYSTALISED(AlchemyObject.ALEMBIC);
+    // Clicking the quick-time event on the Agitator gives 14 experience, this event can happen 1-2 times
+    HOMOGENOUS(AlchemyObject.AGITATOR, 21),
+    // Each click on the Retort gives 2 experience for a max of 10 clicks
+    CONCENTRATED(AlchemyObject.RETORT, 20),
+    // Clicking the quick-time event on the Alembic gives 14 experience
+    CRYSTALISED(AlchemyObject.ALEMBIC, 14);
 
     private static final PotionModifier[] TYPES = PotionModifier.values();
 
     private final AlchemyObject alchemyObject;
+    private final int quickActionExperience;
 
-    PotionModifier(AlchemyObject alchemyObject) {
+    PotionModifier(AlchemyObject alchemyObject, int quickActionExperience) {
         this.alchemyObject = alchemyObject;
+        this.quickActionExperience = quickActionExperience;
     }
 
     public static PotionModifier from(int potionModifierId) {
@@ -22,5 +27,9 @@ public enum PotionModifier {
 
     public AlchemyObject alchemyObject() {
         return alchemyObject;
+    }
+
+    public int quickActionExperience() {
+        return quickActionExperience;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
@@ -10,11 +10,13 @@ public class BestExperienceEvaluator implements PotionOrderEvaluator {
         var bestExperience = 0;
 
         for (PotionOrder order : context.orders()) {
-            var experience = order.potionType().experience();
+            var potionExperience = order.potionType().experience();
+            var modifierExperience = order.potionModifier().quickActionExperience();
+            var totalExperience = potionExperience + modifierExperience;
 
-            if (experience > bestExperience) {
+            if (totalExperience > bestExperience) {
                 bestOrder = order;
-                bestExperience = experience;
+                bestExperience = totalExperience;
             }
         }
         return bestOrder;


### PR DESCRIPTION
This adds a quickTimeExperience field to the PotionModifier class which will be used when evaluating the best experience