### PR TITLE
Allow many orders to be part of strategy output

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -85,7 +85,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private final Map<AlchemyObject, HighlightedObject> highlightedObjects = new LinkedHashMap<>();
     private List<PotionOrder> potionOrders = Collections.emptyList();
-    private PotionOrder bestPotionOrder;
+    private List<PotionOrder> bestPotionOrders;
 
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
@@ -263,11 +263,14 @@ public class MasteringMixologyPlugin extends Plugin {
         }
         updatePotionOrders();
 
-        var bestPotionOrderIdx = bestPotionOrder != null ? bestPotionOrder.idx() : -1;
+        List<Integer> bestPotionOrderIdxs = new ArrayList<>();
+        for (var potionOrder : bestPotionOrders) {
+            bestPotionOrderIdxs.add(potionOrder.idx());
+        }
 
         for (int orderIdx = 1; orderIdx <= 3; orderIdx++) {
             // The first text widget is always the interface title 'Potion Orders'
-            appendPotionRecipe(textComponents.get(orderIdx), orderIdx, bestPotionOrderIdx == orderIdx);
+            appendPotionRecipe(textComponents.get(orderIdx), orderIdx, bestPotionOrderIdxs.contains(orderIdx));
         }
     }
 
@@ -326,7 +329,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 client.getVarpValue(VARP_AGA_RESIN),
                 client.getVarpValue(VARP_MOX_RESIN)
         );
-        bestPotionOrder = strategy.evaluator().evaluate(evaluatorContext);
+        bestPotionOrders = strategy.evaluator().evaluate(evaluatorContext);
     }
 
     private List<Widget> findTextComponents(Widget parent) {

--- a/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
@@ -2,10 +2,14 @@ package work.fking.masteringmixology.evaluator;
 
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BestExperienceEvaluator implements PotionOrderEvaluator {
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         PotionOrder bestOrder = null;
         var bestExperience = 0;
 
@@ -19,6 +23,9 @@ public class BestExperienceEvaluator implements PotionOrderEvaluator {
                 bestExperience = totalExperience;
             }
         }
-        return bestOrder;
+        if (bestOrder != null) {
+            bestPotionOrders.add(bestOrder);
+        }
+        return bestPotionOrders;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
@@ -4,6 +4,9 @@ import work.fking.masteringmixology.PotionComponent;
 import work.fking.masteringmixology.PotionOrder;
 import work.fking.masteringmixology.PotionType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FavorComponentEvaluator implements PotionOrderEvaluator {
 
     private final PotionComponent favoredComponent;
@@ -13,7 +16,8 @@ public class FavorComponentEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         PotionOrder bestOrder = null;
         var bestScore = 0;
 
@@ -24,7 +28,10 @@ public class FavorComponentEvaluator implements PotionOrderEvaluator {
                 bestScore = score;
             }
         }
-        return bestOrder;
+        if (bestOrder != null) {
+            bestPotionOrders.add(bestOrder);
+        }
+        return bestPotionOrders;
     }
 
     private int computePotionScore(PotionType potionType) {

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
@@ -3,6 +3,9 @@ package work.fking.masteringmixology.evaluator;
 import work.fking.masteringmixology.PotionModifier;
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FavorModifierEvaluator implements PotionOrderEvaluator {
 
     private final PotionModifier modifier;
@@ -12,12 +15,13 @@ public class FavorModifierEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         for (var order : context.orders()) {
             if (order.potionModifier() == modifier) {
-                return order;
+                bestPotionOrders.add(order);
             }
         }
-        return null;
+        return bestPotionOrders;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
@@ -7,12 +7,12 @@ import java.util.List;
 public interface PotionOrderEvaluator {
 
     /**
-     * Evaluates all the potion orders and determines which one should be highlighted.
+     * Evaluates all the potion orders and determines which ones should be highlighted.
      *
      * @param context The context containing the potion orders and additional player related information.
-     * @return The potion order to be highlighted.
+     * @return A list of potion orders to be highlighted.
      */
-    PotionOrder evaluate(EvaluatorContext context);
+    List<PotionOrder> evaluate(EvaluatorContext context);
 
     class EvaluatorContext {
 


### PR DESCRIPTION
Since Jagex has changed the activity to allow multiple order turn-ins per order, we need to change the bestPotionOrder object from a single PotionOrder into a List of PotionOrders. I've made this adjustment, renaming the field in the plugin to `bestPotionOrders` (plural)

I edited the existing strategies to output Lists, but I didn't change the actual logic inside those strategies yet, so they are still returning just one PotionOrder inside the list. The one exception is the station-favoring strategies, where I am putting all orders into a list that use the favored station.

I did my best to ensure that a PotionOrder inside the List returned would never be null, but there is perhaps a better way to ensure this in Java, I'm a bit out of practice. Or maybe it's best practice to check for null inside the plugin code after the fact. Open to suggestions here.

I also changed the order widget highlighting logic to be compatible with this change.