### PR TITLE
Change station highlighting scheme to accommodate fulfilling multiple orders at once

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -137,7 +137,7 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         if (!config.highlightStations()) {
-            unHighlightInactiveStations();
+            unHighlightAllStations();
         }
 
         if (!config.highlightDigWeed()) {
@@ -151,8 +151,6 @@ public class MasteringMixologyPlugin extends Plugin {
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event) {
         // First potion in inventory can change due to items being dragged around, destroyed, etc.
-        if (!config.highlightStations()) return;
-
         var inventory = client.getItemContainer(InventoryID.INVENTORY);
         if (inventory == null || !inventory.equals(event.getItemContainer())) {
             return;
@@ -162,6 +160,7 @@ public class MasteringMixologyPlugin extends Plugin {
     }
 
     private void highlightBestStation() {
+        if (!config.highlightStations()) return;
         unHighlightInactiveStations();
 
         var inventory = client.getItemContainer(InventoryID.INVENTORY);
@@ -361,6 +360,13 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.ALEMBIC);
         if (client.getVarbitValue(VARBIT_AGITATOR_POTION) == 0)
             unHighlightObject(AlchemyObject.AGITATOR);
+    }
+
+    private void unHighlightAllStations() {
+        unHighlightObject(AlchemyObject.RETORT);
+        unHighlightObject(AlchemyObject.ALEMBIC);
+        unHighlightObject(AlchemyObject.AGITATOR);
+
     }
 
     private void updatePotionOrders() {

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -25,6 +25,20 @@ public class PotionOrder {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PotionOrder)) {
+            return false;
+        }
+        PotionOrder other = (PotionOrder) o;
+        return idx == other.idx && potionType == other.potionType && potionModifier == other.potionModifier;
+    }
+
+    @Override
+    public int hashCode() {
+        return idx + 31 * potionType.hashCode() + 31 * 31 * potionModifier.hashCode();
+    }
+
+    @Override
     public String toString() {
         return "PotionOrder{" +
                 "idx=" + idx +

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -7,29 +7,31 @@ import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(60, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(60, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(60, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(76, AGA, AGA, AGA),
-    AZURE_AURA_MIX(68, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(72, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(86, LYE, LYE, LYE),
-    MEGALITE_LIQUID(80, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(84, AGA, LYE, LYE),
-    MIXALOT(64, MOX, AGA, LYE);
+    MAMMOTH_MIGHT_MIX(60, 30011, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(60, 30012, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(60, 30013, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(76, 30014, AGA, AGA, AGA),
+    AZURE_AURA_MIX(68, 30016, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(72, 30015, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(86, 30017, LYE, LYE, LYE),
+    MEGALITE_LIQUID(80, 30019, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(84, 30018, AGA, LYE, LYE),
+    MIXALOT(64, 30020, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
 
     private final String recipe;
     private final int levelReq;
+    private final int itemId;
     private final int experience;
     private final PotionComponent[] components;
 
-    PotionType(int levelReq, PotionComponent... components) {
+    PotionType(int levelReq, int itemId, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
         this.levelReq = levelReq;
         this.experience = Arrays.stream(components).mapToInt(PotionComponent::experience).sum();
         this.components = components;
+        this.itemId = itemId;
     }
 
     public static PotionType from(int potionTypeId) {
@@ -63,6 +65,8 @@ public enum PotionType {
     public int experience() {
         return experience;
     }
+
+    public int itemId() { return itemId; }
 
     public PotionComponent[] components() {
         return components;


### PR DESCRIPTION
This changes the station highlighting procedure to better accommodate for the ability to fulfill multiple orders simultaneously. 
Rather than only looking at the potion in the mixer, we first check the player's inventory to find the first potion (which is the potion that will be fed into a station on left-click) and highlight the station that corresponds to that potion, with additional logic if the same potion is requested multiple times at different stations. When completing 3 orders simultaneously, the stations will highlight in sequence, depending on the order of the potions in the player's inventory. If the player has no potions in their inventory, the station corresponding to the potion in the mixer is highlighted as a preview.