### PR TITLE
Inventory highlights and color coded potion stations, supporting many-potion strategies

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -32,30 +32,58 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "highlightInventory",
+            name = "Highlight inventory",
+            description = "Toggles inventory item highlighting on or off",
+            position = 2
+    )
+    default boolean highlightInventory() { return true; }
+
+    @ConfigItem(
             keyName = "highlightStations",
             name = "Highlight stations",
             description = "Toggles alchemical station highlighting on or off",
-            position = 2
+            position = 3
     )
     default boolean highlightStations() {
         return true;
     }
 
     @ConfigItem(
-            keyName = "stationHighlightColor",
-            name = "Station color",
-            description = "Configures the default station highlight color",
-            position = 3
+            keyName = "alembicHighlightColor",
+            name = "Alembic Station color",
+            description = "Configures the alembic station highlight color",
+            position = 4
     )
-    default Color stationHighlightColor() {
+    default Color alembicHighlightColor() {
         return Color.MAGENTA;
+    }
+
+    @ConfigItem(
+            keyName = "agitatorHighlightColor",
+            name = "Agitator Station color",
+            description = "Configures the agitator station highlight color",
+            position = 5
+    )
+    default Color agitatorHighlightColor() {
+        return Color.CYAN;
+    }
+
+    @ConfigItem(
+            keyName = "retortHighlightColor",
+            name = "Retort Station color",
+            description = "Configures the retort station highlight color",
+            position = 6
+    )
+    default Color retortHighlightColor() {
+        return Color.YELLOW;
     }
 
     @ConfigItem(
             keyName = "stationQuickActionHighlightColor",
             name = "Quick-action color",
             description = "Configures the station quick-action highlight color",
-            position = 4
+            position = 7
     )
     default Color stationQuickActionHighlightColor() {
         return Color.GREEN;
@@ -65,7 +93,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "notifyDigweed",
             name = "Notify DigWeed",
             description = "Toggles digweed notifications on or off",
-            position = 5
+            position = 8
     )
     default boolean notifyDigWeed() {
         return true;
@@ -75,7 +103,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightDigweed",
             name = "Highlight DigWeed",
             description = "Toggles digweed highlighting on or off",
-            position = 6
+            position = 9
     )
     default boolean highlightDigWeed() {
         return true;
@@ -85,7 +113,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "digweedHighlightColor",
             name = "DigWeed color",
             description = "Configures the digweed highlight color",
-            position = 7
+            position = 10
     )
     default Color digweedHighlightColor() {
         return Color.GREEN;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyInventoryOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyInventoryOverlay.java
@@ -1,11 +1,10 @@
 package work.fking.masteringmixology;
 
-import javax.inject.Inject;
-
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
+import javax.inject.Inject;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyInventoryOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyInventoryOverlay.java
@@ -1,0 +1,38 @@
+package work.fking.masteringmixology;
+
+import javax.inject.Inject;
+
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+class MasteringMixologyInventoryOverlay extends WidgetItemOverlay
+{
+    private final ItemManager itemManager;
+    private final MasteringMixologyPlugin plugin;
+
+    @Inject
+    private MasteringMixologyInventoryOverlay(ItemManager itemManager, MasteringMixologyPlugin plugin, MasteringMixologyConfig config)
+    {
+        this.itemManager = itemManager;
+        this.plugin = plugin;
+        showOnInventory();
+    }
+
+    @Override
+    public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem)
+    {
+        final Color color = plugin.highlightedItems().get(itemId);
+        if (color == null)
+        {
+            return;
+        }
+
+        Rectangle bounds = widgetItem.getCanvasBounds();
+        final BufferedImage outline = itemManager.getItemOutline(itemId, widgetItem.getQuantity(), color);
+        graphics.drawImage(outline, (int) bounds.getX(), (int) bounds.getY(), null);
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -277,6 +277,7 @@ public class MasteringMixologyPlugin extends Plugin {
         }
         updatePotionOrders();
         updateHighlightedItems();
+        updateHighlightedStations();
 
         List<Integer> bestPotionOrderIdxs = new ArrayList<>();
         for (var potionOrder : bestPotionOrders) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -85,7 +85,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private final Map<AlchemyObject, HighlightedObject> highlightedObjects = new LinkedHashMap<>();
     private List<PotionOrder> potionOrders = Collections.emptyList();
-    private PotionOrder bestPotionOrder;
+    private List<PotionOrder> bestPotionOrders;
 
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
@@ -263,11 +263,14 @@ public class MasteringMixologyPlugin extends Plugin {
         }
         updatePotionOrders();
 
-        var bestPotionOrderIdx = bestPotionOrder != null ? bestPotionOrder.idx() : -1;
+        List<Integer> bestPotionOrderIdxs = new ArrayList<>();
+        for (var potionOrder : bestPotionOrders) {
+            bestPotionOrderIdxs.add(potionOrder.idx());
+        }
 
         for (int orderIdx = 1; orderIdx <= 3; orderIdx++) {
             // The first text widget is always the interface title 'Potion Orders'
-            appendPotionRecipe(textComponents.get(orderIdx), orderIdx, bestPotionOrderIdx == orderIdx);
+            appendPotionRecipe(textComponents.get(orderIdx), orderIdx, bestPotionOrderIdxs.contains(orderIdx));
         }
     }
 
@@ -326,7 +329,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 client.getVarpValue(VARP_AGA_RESIN),
                 client.getVarpValue(VARP_MOX_RESIN)
         );
-        bestPotionOrder = strategy.evaluator().evaluate(evaluatorContext);
+        bestPotionOrders = strategy.evaluator().evaluate(evaluatorContext);
     }
 
     private List<Widget> findTextComponents(Widget parent) {

--- a/src/main/java/work/fking/masteringmixology/PotionModifier.java
+++ b/src/main/java/work/fking/masteringmixology/PotionModifier.java
@@ -1,10 +1,10 @@
 package work.fking.masteringmixology;
 
 public enum PotionModifier {
-    // Clicking the quick-time event on the Agitator gives 14 experience, this event can happen 1-2 times
-    HOMOGENOUS(AlchemyObject.AGITATOR, 21),
-    // Each click on the Retort gives 2 experience for a max of 10 clicks
-    CONCENTRATED(AlchemyObject.RETORT, 20),
+    // Clicking the quick-time event on the Agitator gives 14 experience
+    HOMOGENOUS(AlchemyObject.AGITATOR, 14),
+    // Each click on the Retort gives 2 experience for a max of 7 clicks
+    CONCENTRATED(AlchemyObject.RETORT, 14),
     // Clicking the quick-time event on the Alembic gives 14 experience
     CRYSTALISED(AlchemyObject.ALEMBIC, 14);
 

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -7,27 +7,31 @@ import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(60, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(60, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(60, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(76, AGA, AGA, AGA),
-    AZURE_AURA_MIX(68, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(72, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(86, LYE, LYE, LYE),
-    MEGALITE_LIQUID(80, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(84, AGA, LYE, LYE),
-    MIXALOT(64, MOX, AGA, LYE);
+    MAMMOTH_MIGHT_MIX(60, 30011, 30021, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(60, 30012, 30022, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(60, 30013, 30023, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(76, 30014, 30024, AGA, AGA, AGA),
+    AZURE_AURA_MIX(68, 30016, 30026, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(72, 30015, 30025, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(86, 30017, 30027, LYE, LYE, LYE),
+    MEGALITE_LIQUID(80, 30019, 30029, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(84, 30018, 30028, AGA, LYE, LYE),
+    MIXALOT(64, 30020, 30030, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
 
     private final String recipe;
     private final int levelReq;
+    private final int unfinishedItemId;
+    private final int finishedItemId;
     private final int experience;
     private final PotionComponent[] components;
 
-    PotionType(int levelReq, PotionComponent... components) {
+    PotionType(int levelReq, int unfinishedItemId, int finishedItemId, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
         this.levelReq = levelReq;
+        this.unfinishedItemId = unfinishedItemId;
+        this.finishedItemId = finishedItemId;
         this.experience = Arrays.stream(components).mapToInt(PotionComponent::experience).sum();
         this.components = components;
     }
@@ -58,6 +62,14 @@ public enum PotionType {
 
     public int levelReq() {
         return levelReq;
+    }
+
+    public int unfinishedItemId() {
+        return unfinishedItemId;
+    }
+
+    public int finishedItemId() {
+        return finishedItemId;
     }
 
     public int experience() {

--- a/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
@@ -2,10 +2,14 @@ package work.fking.masteringmixology.evaluator;
 
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BestExperienceEvaluator implements PotionOrderEvaluator {
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         PotionOrder bestOrder = null;
         var bestExperience = 0;
 
@@ -19,6 +23,9 @@ public class BestExperienceEvaluator implements PotionOrderEvaluator {
                 bestExperience = totalExperience;
             }
         }
-        return bestOrder;
+        if (bestOrder != null) {
+            bestPotionOrders.add(bestOrder);
+        }
+        return bestPotionOrders;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
@@ -4,6 +4,9 @@ import work.fking.masteringmixology.PotionComponent;
 import work.fking.masteringmixology.PotionOrder;
 import work.fking.masteringmixology.PotionType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FavorComponentEvaluator implements PotionOrderEvaluator {
 
     private final PotionComponent favoredComponent;
@@ -13,7 +16,8 @@ public class FavorComponentEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         PotionOrder bestOrder = null;
         var bestScore = 0;
 
@@ -24,7 +28,10 @@ public class FavorComponentEvaluator implements PotionOrderEvaluator {
                 bestScore = score;
             }
         }
-        return bestOrder;
+        if (bestOrder != null) {
+            bestPotionOrders.add(bestOrder);
+        }
+        return bestPotionOrders;
     }
 
     private int computePotionScore(PotionType potionType) {

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
@@ -3,6 +3,9 @@ package work.fking.masteringmixology.evaluator;
 import work.fking.masteringmixology.PotionModifier;
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class FavorModifierEvaluator implements PotionOrderEvaluator {
 
     private final PotionModifier modifier;
@@ -12,12 +15,13 @@ public class FavorModifierEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public List<PotionOrder> evaluate(EvaluatorContext context) {
+        List<PotionOrder> bestPotionOrders = new ArrayList<>();
         for (var order : context.orders()) {
             if (order.potionModifier() == modifier) {
-                return order;
+                bestPotionOrders.add(order);
             }
         }
-        return null;
+        return bestPotionOrders;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
@@ -7,12 +7,12 @@ import java.util.List;
 public interface PotionOrderEvaluator {
 
     /**
-     * Evaluates all the potion orders and determines which one should be highlighted.
+     * Evaluates all the potion orders and determines which ones should be highlighted.
      *
      * @param context The context containing the potion orders and additional player related information.
-     * @return The potion order to be highlighted.
+     * @return A list of potion orders to be highlighted.
      */
-    PotionOrder evaluate(EvaluatorContext context);
+    List<PotionOrder> evaluate(EvaluatorContext context);
 
     class EvaluatorContext {
 


### PR DESCRIPTION
This PR is in a stack behind [this PR which enables multiple PotionOrders in strategy output.](https://github.com/hex-agon/mastering-mixology/pull/25)

With the hotfixes that Jagex implemented last week, it is helpful to highlight unfinished potions in the inventory to indicate which station each potion should be finished on. Also, we should be able to highlight these potions immediately on receiving a new order, since a player may be pre-mixing potions and have them in the inventory. We also need to be re-highlighting a potion station if there is still an order to be completed at that station.

This PR:
- Adds an Inventory overlay for item highlighting
- Removes items from the `bestPotionOrders` list as we process those completed potions
- changes the object/item highlighting methods to pivot on the values inside the `bestPotionOrders` list, as well as what items are in the inventory and what potion is in the Mixing Vessel.
- corrects the xp values for each potion station
- Adds a separate config value for Inventory Highlighting
- Adds separate config options to color each Potion Station (these colors are also used on unfinished potions that go with those stations)

Feedback welcome!