### PR TITLE
Strategy-agnostic station/potion highlighting + more robust strategy evaluator

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -3,6 +3,9 @@
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
+    <module name="LineLength">
+        <property name="max" value="220"/>
+    </module>
     <module name="TreeWalker">
         <module name="AvoidStarImport"/>
         <module name="UnnecessaryParentheses"/>

--- a/src/main/java/work/fking/masteringmixology/AlchemyObject.java
+++ b/src/main/java/work/fking/masteringmixology/AlchemyObject.java
@@ -27,6 +27,14 @@ public enum AlchemyObject {
         this.coordinate = coordinate;
     }
 
+    public boolean isStation() {
+        return this == RETORT || this == AGITATOR || this == ALEMBIC || this == MIXING_VESSEL;
+    }
+
+    public boolean isDigweed() {
+        return this == DIGWEED_NORTH_EAST || this == DIGWEED_SOUTH_EAST || this == DIGWEED_SOUTH_WEST || this == DIGWEED_NORTH_WEST;
+    }
+
     public int objectId() {
         return objectId;
     }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -14,6 +14,54 @@ public interface MasteringMixologyConfig extends Config {
 
     String CONFIG_GROUP = "masteringmixology";
 
+    @ConfigItem(
+            keyName = "strategy",
+            name = "Strategy",
+            description = "Selects the potion order highlighting strategy"
+    )
+    default Strategy strategy() {
+        return Strategy.FAVOR_EXPERIENCE;
+    }
+
+    @ConfigItem(
+            keyName = "sortComponentNames",
+            name = "Sort component prefixes",
+            description = "Toggles sorting of potion recipes in the orders interface. The sort order is M < A < L."
+    )
+    default boolean sortComponentNames() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "highlightStations",
+            name = "Highlight potions and stations",
+            description = "Toggles alchemical potion/station highlighting on or off"
+    )
+    default boolean highlightStations() {
+        return true;
+    }
+
+
+    @ConfigItem(
+            keyName = "notifyDigweed",
+            name = "Notify DigWeed",
+            description = "Toggles digweed notifications on or off"
+    )
+    default boolean notifyDigWeed() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "highlightDigweed",
+            name = "Highlight DigWeed",
+            description = "Toggles digweed highlighting on or off"
+    )
+    default boolean highlightDigWeed() {
+        return true;
+    }
+
+
+
     @ConfigSection(
             name = "Highlights",
             description = "Highlighting related configuration",
@@ -22,30 +70,11 @@ public interface MasteringMixologyConfig extends Config {
     String HIGHLIGHTS = "Highlights";
 
     @ConfigItem(
-            keyName = "strategy",
-            name = "Strategy",
-            description = "Selects the potion order highlighting strategy",
-            position = 1
-    )
-    default Strategy strategy() {
-        return Strategy.FAVOR_EXPERIENCE;
-    }
-
-    @ConfigItem(
-            keyName = "highlightStations",
-            name = "Highlight potions and stations",
-            description = "Toggles alchemical potion/station highlighting on or off",
-            position = 2
-    )
-    default boolean highlightStations() {
-        return true;
-    }
-
-    @ConfigItem(
             keyName = "retortHighlightColor",
             name = "Retort station color",
             description = "Configures the default retort station highlight color",
-            position = 3
+            position = 1,
+            section = HIGHLIGHTS
     )
     default Color retortHighlightColor() {
         return Color.MAGENTA;
@@ -55,7 +84,8 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "agitatorHighlightColor",
             name = "Agitator station color",
             description = "Configures the default agitator station highlight color",
-            position = 4
+            position = 2,
+            section = HIGHLIGHTS
     )
     default Color agitatorHighlightColor() {
         return Color.YELLOW;
@@ -65,7 +95,8 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "alembicHighlightColor",
             name = "Alembic station color",
             description = "Configures the default retort station highlight color",
-            position = 5
+            position = 3,
+            section = HIGHLIGHTS
     )
     default Color alembicHighlightColor() {
         return Color.CYAN;
@@ -75,37 +106,19 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "stationQuickActionHighlightColor",
             name = "Quick-action color",
             description = "Configures the station quick-action highlight color",
-            position = 6
+            position = 4,
+            section = HIGHLIGHTS
     )
     default Color stationQuickActionHighlightColor() {
         return Color.GREEN;
     }
 
     @ConfigItem(
-            keyName = "notifyDigweed",
-            name = "Notify DigWeed",
-            description = "Toggles digweed notifications on or off",
-            position = 7
-    )
-    default boolean notifyDigWeed() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "highlightDigweed",
-            name = "Highlight DigWeed",
-            description = "Toggles digweed highlighting on or off",
-            position = 8
-    )
-    default boolean highlightDigWeed() {
-        return true;
-    }
-
-    @ConfigItem(
             keyName = "digweedHighlightColor",
             name = "DigWeed color",
             description = "Configures the digweed highlight color",
-            position = 9
+            position = 5,
+            section = HIGHLIGHTS
     )
     default Color digweedHighlightColor() {
         return Color.GREEN;
@@ -115,7 +128,8 @@ public interface MasteringMixologyConfig extends Config {
             section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",
-            description = "Configures the border width of the object highlights"
+            description = "Configures the border width of the object highlights",
+            position = 6
     )
     default int highlightBorderWidth() {
         return 2;
@@ -125,7 +139,8 @@ public interface MasteringMixologyConfig extends Config {
             section = HIGHLIGHTS,
             keyName = "highlightFeather",
             name = "Feather",
-            description = "Configures the amount of 'feathering' to be applied to the object highlights"
+            description = "Configures the amount of 'feathering' to be applied to the object highlights",
+            position = 7
     )
     default int highlightFeather() {
         return 1;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -57,7 +57,9 @@ public interface MasteringMixologyConfig extends Config {
             description = "Configures the default agitator station highlight color",
             position = 4
     )
-    default Color agitatorHighlightColor() {return Color.YELLOW;}
+    default Color agitatorHighlightColor() {
+        return Color.YELLOW;
+    }
 
     @ConfigItem(
             keyName = "alembicHighlightColor",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -33,8 +33,8 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             keyName = "highlightStations",
-            name = "Highlight stations",
-            description = "Toggles alchemical station highlighting on or off",
+            name = "Highlight potions and stations",
+            description = "Toggles alchemical potion/station highlighting on or off",
             position = 2
     )
     default boolean highlightStations() {
@@ -42,20 +42,38 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "stationHighlightColor",
-            name = "Station color",
-            description = "Configures the default station highlight color",
+            keyName = "retortHighlightColor",
+            name = "Retort station color",
+            description = "Configures the default retort station highlight color",
             position = 3
     )
-    default Color stationHighlightColor() {
+    default Color retortHighlightColor() {
         return Color.MAGENTA;
+    }
+
+    @ConfigItem(
+            keyName = "agitatorHighlightColor",
+            name = "Agitator station color",
+            description = "Configures the default agitator station highlight color",
+            position = 4
+    )
+    default Color agitatorHighlightColor() {return Color.YELLOW;}
+
+    @ConfigItem(
+            keyName = "alembicHighlightColor",
+            name = "Alembic station color",
+            description = "Configures the default retort station highlight color",
+            position = 5
+    )
+    default Color alembicHighlightColor() {
+        return Color.CYAN;
     }
 
     @ConfigItem(
             keyName = "stationQuickActionHighlightColor",
             name = "Quick-action color",
             description = "Configures the station quick-action highlight color",
-            position = 4
+            position = 6
     )
     default Color stationQuickActionHighlightColor() {
         return Color.GREEN;
@@ -65,7 +83,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "notifyDigweed",
             name = "Notify DigWeed",
             description = "Toggles digweed notifications on or off",
-            position = 5
+            position = 7
     )
     default boolean notifyDigWeed() {
         return true;
@@ -75,7 +93,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightDigweed",
             name = "Highlight DigWeed",
             description = "Toggles digweed highlighting on or off",
-            position = 6
+            position = 8
     )
     default boolean highlightDigWeed() {
         return true;
@@ -85,7 +103,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "digweedHighlightColor",
             name = "DigWeed color",
             description = "Configures the digweed highlight color",
-            position = 7
+            position = 9
     )
     default Color digweedHighlightColor() {
         return Color.GREEN;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
@@ -12,15 +12,21 @@ import java.util.Collections;
 public class MasteringMixologyItemOverlay extends WidgetItemOverlay {
 
     private final MasteringMixologyPlugin plugin;
+    private final MasteringMixologyConfig config;
 
     @Inject
-    protected MasteringMixologyItemOverlay(MasteringMixologyPlugin plugin) {
+    protected MasteringMixologyItemOverlay(MasteringMixologyPlugin plugin, MasteringMixologyConfig config) {
         this.plugin = plugin;
+        this.config = config;
         showOnInventory();
     }
 
     @Override
     public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem) {
+
+        if (!config.highlightStations()) {
+            return;
+        }
 
         var requiredModifiers = plugin.getRequiredModifiers(itemId);
         if (requiredModifiers.isEmpty()) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
@@ -1,0 +1,39 @@
+package work.fking.masteringmixology;
+
+import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.ui.overlay.WidgetItemOverlay;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.util.Collections;
+
+public class MasteringMixologyItemOverlay extends WidgetItemOverlay {
+
+    private final MasteringMixologyPlugin plugin;
+
+    @Inject
+    protected MasteringMixologyItemOverlay(MasteringMixologyPlugin plugin) {
+        this.plugin = plugin;
+        showOnInventory();
+    }
+
+    @Override
+    public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem) {
+
+        var requiredModifiers = plugin.getRequiredModifiers(itemId);
+        if (requiredModifiers.isEmpty()) { return; }
+
+        Collections.sort(requiredModifiers);
+
+        Rectangle bounds = widgetItem.getCanvasBounds();
+        float arcLength = 360f / requiredModifiers.size();
+
+        for (int i = 0; i < requiredModifiers.size(); i++) {
+            Color c = plugin.getHighlightColor(requiredModifiers.get(i));
+            graphics.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha()/3));
+            graphics.fillArc((int) bounds.getX(), (int) bounds.getY(), (int) bounds.getWidth(), (int) bounds.getHeight(), (int) (i*arcLength), (int) arcLength);
+        }
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyItemOverlay.java
@@ -23,7 +23,9 @@ public class MasteringMixologyItemOverlay extends WidgetItemOverlay {
     public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem widgetItem) {
 
         var requiredModifiers = plugin.getRequiredModifiers(itemId);
-        if (requiredModifiers.isEmpty()) { return; }
+        if (requiredModifiers.isEmpty()) {
+            return;
+        }
 
         Collections.sort(requiredModifiers);
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -97,8 +97,6 @@ public class MasteringMixologyPlugin extends Plugin {
     // Whatever the player is currently processing
     private PotionModifier activeModifier = null;
 
-    private final Map<PotionType, Integer> counts = new HashMap<>();
-
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
     }
@@ -404,11 +402,6 @@ public class MasteringMixologyPlugin extends Plugin {
 
         var newOrders = getPotionOrders();
         if (!potionOrders.equals(newOrders)) {
-            for (var order : newOrders) {
-                PotionType type = order.potionType();
-                counts.compute(type, (k, count) -> count == null ? 1 : count + 1);
-            }
-
             // Update required modifiers map
             requiredModifiers.clear();
             for (var order : newOrders) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -153,8 +153,12 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         if (!config.highlightStations()) {
+            overlayManager.remove(overlay);
+            overlayManager.remove(itemOverlay);
             unHighlightAllStations();
         } else {
+            overlayManager.add(overlay);
+            overlayManager.add(itemOverlay);
             updateStationHighlights();
         }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -171,9 +171,13 @@ public class MasteringMixologyPlugin extends Plugin {
     }
 
     private void tryFulfillOrder(PotionType potionType, PotionModifier modifier) {
-        if (potionType == null) return;
+        if (potionType == null) {
+            return;
+        }
         var counts = requiredModifiers.get(potionType.itemId());
-        if (counts == null) return;
+        if (counts == null) {
+            return;
+        }
         counts.compute(modifier, (k, count) -> count == null ? null : count - 1);
     }
 
@@ -190,9 +194,13 @@ public class MasteringMixologyPlugin extends Plugin {
     /** Returns color that the mixing vessel should be highlighted, or null if it shouldn't be highlighted. */
     private Color handleMixingVesselVarbit(int value) {
         PotionType type = PotionType.from(value - 1);
-        if (type == null) return null;
+        if (type == null) {
+            return null;
+        }
         List<PotionModifier> reqs = getRequiredModifiers(type.itemId());
-        if (reqs.isEmpty()) return null;
+        if (reqs.isEmpty()) {
+            return null;
+        }
         int r = 0, g = 0, b = 0, a = 0;
         for (PotionModifier modifier : reqs) {
             Color c = getHighlightColor(modifier);
@@ -385,7 +393,9 @@ public class MasteringMixologyPlugin extends Plugin {
     public List<PotionModifier> getRequiredModifiers(int potionItemId) {
         var res = new ArrayList<PotionModifier>();
         var map = requiredModifiers.get(potionItemId);
-        if (map == null) return res;
+        if (map == null) {
+            return res;
+        }
 
         for (var entry : map.entrySet()) {
             if (entry.getValue() > 0) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -165,6 +165,10 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.DIGWEED_SOUTH_WEST);
             unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
         }
+
+        if (event.getKey().equals("sortComponentNames")) {
+            PotionType.regenerateRecipes(config.sortComponentNames());
+        }
     }
 
     private void tryFulfillOrder(PotionType potionType, PotionModifier modifier) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -137,7 +137,7 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         if (!config.highlightStations()) {
-            unHighlightInactiveStations();
+            unHighlightAllStations();
         }
 
         if (!config.highlightDigWeed()) {
@@ -151,8 +151,6 @@ public class MasteringMixologyPlugin extends Plugin {
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event) {
         // First potion in inventory can change due to items being dragged around, destroyed, etc.
-        if (!config.highlightStations()) return;
-
         var inventory = client.getItemContainer(InventoryID.INVENTORY);
         if (inventory == null || !inventory.equals(event.getItemContainer())) {
             return;
@@ -162,6 +160,7 @@ public class MasteringMixologyPlugin extends Plugin {
     }
 
     private void highlightBestStation() {
+        if (!config.highlightStations()) return;
         unHighlightInactiveStations();
 
         var inventory = client.getItemContainer(InventoryID.INVENTORY);
@@ -361,6 +360,13 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.ALEMBIC);
         if (client.getVarbitValue(VARBIT_AGITATOR_POTION) == 0)
             unHighlightObject(AlchemyObject.AGITATOR);
+    }
+
+    private void unHighlightAllStations() {
+        unHighlightObject(AlchemyObject.RETORT);
+        unHighlightObject(AlchemyObject.ALEMBIC);
+        unHighlightObject(AlchemyObject.AGITATOR);
+
     }
 
     private void updatePotionOrders() {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -311,7 +311,7 @@ public class MasteringMixologyPlugin extends Plugin {
         updateMixingVesselHighlight();
 
         Map<PotionOrder, Integer> scores = computeOrderScores();
-        int maxScore = 0;
+        float maxScore = 0.001f;
         for (int score : scores.values()) {
             if (score > maxScore) {
                 maxScore = score;
@@ -321,7 +321,7 @@ public class MasteringMixologyPlugin extends Plugin {
         // The first text widget is always the interface title 'Potion Orders'
         for (PotionOrder order : potionOrders) {
             int i = order.idx();
-            appendPotionRecipe(textComponents.get(i), i, scores.get(order) / (float) maxScore);
+            appendPotionRecipe(textComponents.get(i), i, scores.getOrDefault(order, 0) / maxScore);
         }
     }
 
@@ -346,7 +346,7 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
         if (highlightStrength > 0f) {
-            String hex = Integer.toHexString((int) (Math.max(0f, Math.min(255f, 256f * highlightStrength))));
+            String hex = String.format("%02X", (int) (Math.max(0f, Math.min(255f, 256f * highlightStrength))));
             component.setText("<col=00" + hex + "00>" + component.getText() + "</col> (" + potionType.recipe() + ")");
         } else {
             component.setText(component.getText() + " (" + potionType.recipe() + ")");

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -319,8 +319,9 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         // The first text widget is always the interface title 'Potion Orders'
-        for (int i = 1; i <= potionOrders.size(); i++) {
-            appendPotionRecipe(textComponents.get(i), i, scores.get(potionOrders.get(i-1)) / (float) maxScore);
+        for (PotionOrder order : potionOrders) {
+            int i = order.idx();
+            appendPotionRecipe(textComponents.get(i), i, scores.get(order) / (float) maxScore);
         }
     }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -154,12 +154,8 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         if (!config.highlightStations()) {
-            overlayManager.remove(overlay);
-            overlayManager.remove(itemOverlay);
             unHighlightAllStations();
         } else {
-            overlayManager.add(overlay);
-            overlayManager.add(itemOverlay);
             updateStationHighlights();
             updateMixingVesselHighlight();
         }
@@ -244,9 +240,7 @@ public class MasteringMixologyPlugin extends Plugin {
             handleStationVarbit(PotionModifier.CONCENTRATED, value);
         } else if (varbitId == VARBIT_DIGWEED_NORTH_EAST) {
             if (value == 1) {
-                if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor());
-                }
+                highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor());
                 if (config.notifyDigWeed()) {
                     notifier.notify("A digweed has spawned north east.");
                 }
@@ -255,9 +249,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_EAST) {
             if (value == 1) {
-                if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor());
-                }
+                highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor());
                 if (config.notifyDigWeed()) {
                     notifier.notify("A digweed has spawned south east.");
                 }
@@ -266,9 +258,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_WEST) {
             if (value == 1) {
-                if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor());
-                }
+                highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor());
                 if (config.notifyDigWeed()) {
                     notifier.notify("A digweed has spawned south west.");
                 }
@@ -277,9 +267,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
         } else if (varbitId == VARBIT_DIGWEED_NORTH_WEST) {
             if (value == 1) {
-                if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor());
-                }
+                highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor());
                 if (config.notifyDigWeed()) {
                     notifier.notify("A digweed has spawned north west.");
                 }
@@ -364,6 +352,15 @@ public class MasteringMixologyPlugin extends Plugin {
     }
 
     public void highlightObject(AlchemyObject alchemyObject, Color color) {
+
+        if (alchemyObject.isDigweed() && !config.highlightDigWeed()) {
+            return;
+        }
+
+        if (alchemyObject.isStation() && !config.highlightStations()) {
+            return;
+        }
+
         var worldView = client.getTopLevelWorldView();
 
         if (worldView == null) {

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,18 +1,16 @@
 package work.fking.masteringmixology;
 
 public enum PotionComponent {
-    AGA('A', "00e676", 850),
-    LYE('L', "e91e63", 1250),
-    MOX('M', "03a9f4", 450);
+    AGA('A', "00e676"),
+    LYE('L', "e91e63"),
+    MOX('M', "03a9f4");
 
     private final char character;
     private final String color;
-    private final int experience;
 
-    PotionComponent(char character, String color, int experience) {
+    PotionComponent(char character, String color) {
         this.character = character;
         this.color = color;
-        this.experience = experience;
     }
 
     public char character() {
@@ -22,8 +20,5 @@ public enum PotionComponent {
     public String color() {
         return color;
     }
-
-    public int experience() {
-        return experience;
-    }
 }
+

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,9 +1,9 @@
 package work.fking.masteringmixology;
 
 public enum PotionComponent {
+    MOX('M', "03a9f4"),
     AGA('A', "00e676"),
-    LYE('L', "e91e63"),
-    MOX('M', "03a9f4");
+    LYE('L', "e91e63");
 
     private final char character;
     private final String color;

--- a/src/main/java/work/fking/masteringmixology/PotionModifier.java
+++ b/src/main/java/work/fking/masteringmixology/PotionModifier.java
@@ -1,8 +1,8 @@
 package work.fking.masteringmixology;
 
 public enum PotionModifier {
-    // Clicking the quick-time event on the Agitator gives 14 experience, this event can happen 1-2 times
-    HOMOGENOUS(AlchemyObject.AGITATOR, 21),
+    // Clicking the quick-time event on the Agitator gives 14 experience
+    HOMOGENOUS(AlchemyObject.AGITATOR, 14),
     // Each click on the Retort gives 2 experience for a max of 6 clicks
     CONCENTRATED(AlchemyObject.RETORT, 12),
     // Clicking the quick-time event on the Alembic gives 14 experience

--- a/src/main/java/work/fking/masteringmixology/PotionModifier.java
+++ b/src/main/java/work/fking/masteringmixology/PotionModifier.java
@@ -3,8 +3,8 @@ package work.fking.masteringmixology;
 public enum PotionModifier {
     // Clicking the quick-time event on the Agitator gives 14 experience, this event can happen 1-2 times
     HOMOGENOUS(AlchemyObject.AGITATOR, 21),
-    // Each click on the Retort gives 2 experience for a max of 10 clicks
-    CONCENTRATED(AlchemyObject.RETORT, 20),
+    // Each click on the Retort gives 2 experience for a max of 6 clicks
+    CONCENTRATED(AlchemyObject.RETORT, 12),
     // Clicking the quick-time event on the Alembic gives 14 experience
     CRYSTALISED(AlchemyObject.ALEMBIC, 14);
 

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -30,12 +30,12 @@ public class PotionOrder {
             return false;
         }
         PotionOrder other = (PotionOrder) o;
-        return idx == other.idx;
+        return idx == other.idx && potionType == other.potionType && potionModifier == other.potionModifier;
     }
 
     @Override
     public int hashCode() {
-        return Integer.hashCode(idx);
+        return idx + 31 * potionType.hashCode() + 31 * 31 * potionModifier.hashCode();
     }
 
     @Override

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -25,6 +25,20 @@ public class PotionOrder {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PotionOrder)) {
+            return false;
+        }
+        PotionOrder other = (PotionOrder) o;
+        return idx == other.idx && potionType == other.potionType && potionModifier == other.potionModifier;
+    }
+
+    @Override
+    public int hashCode() {
+        return idx + 31 * potionType.hashCode() + 31 * 31 * potionModifier.hashCode();
+    }
+
+    @Override
     public String toString() {
         return "PotionOrder{" +
                 "idx=" + idx +

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -30,12 +30,12 @@ public class PotionOrder {
             return false;
         }
         PotionOrder other = (PotionOrder) o;
-        return idx == other.idx && potionType == other.potionType && potionModifier == other.potionModifier;
+        return idx == other.idx;
     }
 
     @Override
     public int hashCode() {
-        return idx + 31 * potionType.hashCode() + 31 * 31 * potionModifier.hashCode();
+        return Integer.hashCode(idx);
     }
 
     @Override

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -1,7 +1,9 @@
 package work.fking.masteringmixology;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static work.fking.masteringmixology.PotionComponent.AGA;
@@ -9,16 +11,17 @@ import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(60, 30011, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(60, 30012, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(60, 30013, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(76, 30014, AGA, AGA, AGA),
-    AZURE_AURA_MIX(68, 30016, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(72, 30015, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(86, 30017, LYE, LYE, LYE),
-    MEGALITE_LIQUID(80, 30019, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(84, 30018, AGA, LYE, LYE),
-    MIXALOT(64, 30020, MOX, AGA, LYE);
+    // Multiply exp by 10 to account for the fact that exp has 1 hidden decimal point of precision
+    MAMMOTH_MIGHT_MIX(60, 30011, 1900, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(63, 30012, 2150, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(66, 30013, 2400, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(60, 30014, 1900, AGA, AGA, AGA),
+    AZURE_AURA_MIX(69, 30016, 2650, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(72, 30015, 2900, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(60, 30017, 1900, LYE, LYE, LYE),
+    MEGALITE_LIQUID(75, 30019, 3150, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(78, 30018, 3400, AGA, LYE, LYE),
+    MIXALOT(81, 30020, 3650, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
     public static final Set<Integer> ALL_POTION_IDS = new HashSet<>();
@@ -33,14 +36,67 @@ public enum PotionType {
     private final int levelReq;
     private final int itemId;
     private final int experience;
+    private final Map<PotionComponent, Integer> pointRewards = new HashMap<>();
     private final PotionComponent[] components;
 
-    PotionType(int levelReq, int itemId, PotionComponent... components) {
+    PotionType(int levelReq, int itemId, int experience, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
         this.levelReq = levelReq;
-        this.experience = Arrays.stream(components).mapToInt(PotionComponent::experience).sum();
+        this.experience = experience;
         this.components = components;
         this.itemId = itemId;
+        switch (this) {
+            case MAMMOTH_MIGHT_MIX:
+                pointRewards.put(MOX, 2);
+                pointRewards.put(AGA, 0);
+                pointRewards.put(LYE, 0);
+                break;
+            case MYSTIC_MANA_AMALGAM:
+                pointRewards.put(MOX, 2);
+                pointRewards.put(AGA, 1);
+                pointRewards.put(LYE, 0);
+                break;
+            case MARLEYS_MOONLIGHT:
+                pointRewards.put(MOX, 2);
+                pointRewards.put(AGA, 0);
+                pointRewards.put(LYE, 1);
+                break;
+            case ALCO_AUGMENTATOR:
+                pointRewards.put(MOX, 0);
+                pointRewards.put(AGA, 2);
+                pointRewards.put(LYE, 0);
+                break;
+            case AZURE_AURA_MIX:
+                pointRewards.put(MOX, 1);
+                pointRewards.put(AGA, 2);
+                pointRewards.put(LYE, 0);
+                break;
+            case AQUALUX_AMALGAM:
+                pointRewards.put(MOX, 0);
+                pointRewards.put(AGA, 2);
+                pointRewards.put(LYE, 1);
+                break;
+            case LIPLACK_LIQUOR:
+                pointRewards.put(MOX, 0);
+                pointRewards.put(AGA, 0);
+                pointRewards.put(LYE, 2);
+                break;
+            case MEGALITE_LIQUID:
+                pointRewards.put(MOX, 1);
+                pointRewards.put(AGA, 0);
+                pointRewards.put(LYE, 2);
+                break;
+            case ANTI_LEECH_LOTION:
+                pointRewards.put(MOX, 0);
+                pointRewards.put(AGA, 1);
+                pointRewards.put(LYE, 2);
+                break;
+            case MIXALOT:
+                pointRewards.put(MOX, 2);
+                pointRewards.put(AGA, 2);
+                pointRewards.put(LYE, 2);
+                break;
+        }
     }
 
     public static PotionType from(int potionTypeId) {

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -7,29 +7,31 @@ import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(60, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(60, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(60, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(76, AGA, AGA, AGA),
-    AZURE_AURA_MIX(68, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(72, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(86, LYE, LYE, LYE),
-    MEGALITE_LIQUID(80, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(84, AGA, LYE, LYE),
-    MIXALOT(64, MOX, AGA, LYE);
+    MAMMOTH_MIGHT_MIX(60, 30011, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(60, 30012, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(60, 30013, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(76, 30014, AGA, AGA, AGA),
+    AZURE_AURA_MIX(68, 30016, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(72, 30015, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(86, 30017, LYE, LYE, LYE),
+    MEGALITE_LIQUID(80, 30019, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(84, 30018, AGA, LYE, LYE),
+    MIXALOT(64, 30020, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
 
     private final String recipe;
     private final int levelReq;
+    private final int itemId;
     private final int experience;
     private final PotionComponent[] components;
 
-    PotionType(int levelReq, PotionComponent... components) {
+    PotionType(int levelReq, int itemId, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
         this.levelReq = levelReq;
         this.experience = Arrays.stream(components).mapToInt(PotionComponent::experience).sum();
         this.components = components;
+        this.itemId = itemId;
     }
 
     public static PotionType from(int potionTypeId) {
@@ -63,6 +65,8 @@ public enum PotionType {
     public int experience() {
         return experience;
     }
+
+    public int itemId() { return itemId; }
 
     public PotionComponent[] components() {
         return components;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -1,6 +1,8 @@
 package work.fking.masteringmixology;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static work.fking.masteringmixology.PotionComponent.AGA;
 import static work.fking.masteringmixology.PotionComponent.LYE;
@@ -19,6 +21,13 @@ public enum PotionType {
     MIXALOT(64, 30020, MOX, AGA, LYE);
 
     private static final PotionType[] TYPES = PotionType.values();
+    public static final Set<Integer> ALL_POTION_IDS = new HashSet<>();
+
+    static {
+        for (PotionType type : TYPES) {
+            ALL_POTION_IDS.add(type.itemId());
+        }
+    }
 
     private final String recipe;
     private final int levelReq;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -75,7 +75,9 @@ public enum PotionType {
         return experience;
     }
 
-    public int itemId() { return itemId; }
+    public int itemId() {
+        return itemId;
+    }
 
     public PotionComponent[] components() {
         return components;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -1,6 +1,7 @@
 package work.fking.masteringmixology;
 
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -36,7 +37,7 @@ public enum PotionType {
     private final int levelReq;
     private final int itemId;
     private final int experience;
-    private final Map<PotionComponent, Integer> pointRewards = new HashMap<>();
+    private final Map<PotionComponent, Integer> pointRewards = new EnumMap<>(PotionComponent.class);
     private final PotionComponent[] components;
 
     PotionType(int levelReq, int itemId, int experience, PotionComponent... components) {
@@ -117,6 +118,11 @@ public enum PotionType {
 
     private static String colorizeRecipeComponent(PotionComponent component) {
         return "<col=" + component.color() + ">" + component.character() + "</col>";
+    }
+
+    /** How much of a particular component is rewarded when an order with this type is fulfilled */
+    public int getReward(PotionComponent component) {
+        return pointRewards.getOrDefault(component, 0);
     }
 
     public String recipe() {

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -32,12 +32,12 @@ public enum PotionType {
         }
     }
 
-    private final String recipe;
+    private String recipe;
     private final int levelReq;
     private final int itemId;
     private final int experience;
-    private final Map<PotionComponent, Integer> pointRewards = new EnumMap<>(PotionComponent.class);
     private final PotionComponent[] components;
+    private final Map<PotionComponent, Integer> pointRewards = new EnumMap<>(PotionComponent.class);
 
     PotionType(int levelReq, int itemId, int experience, PotionComponent... components) {
         this.recipe = colorizeRecipe(components);
@@ -113,6 +113,18 @@ public enum PotionType {
         return colorizeRecipeComponent(components[0])
                 + colorizeRecipeComponent(components[1])
                 + colorizeRecipeComponent(components[2]);
+    }
+
+    public static void regenerateRecipes(boolean sort) {
+        for (PotionType type : TYPES) {
+            if (sort) {
+                PotionComponent[] sorted = Arrays.copyOf(type.components, type.components.length);
+                Arrays.sort(sorted);
+                type.recipe = colorizeRecipe(sorted);
+            } else {
+                type.recipe = colorizeRecipe(type.components);
+            }
+        }
     }
 
     private static String colorizeRecipeComponent(PotionComponent component) {

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -2,7 +2,6 @@ package work.fking.masteringmixology;
 
 import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -139,9 +138,5 @@ public enum PotionType {
 
     public int itemId() {
         return itemId;
-    }
-
-    public PotionComponent[] components() {
-        return components;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/Strategy.java
+++ b/src/main/java/work/fking/masteringmixology/Strategy.java
@@ -12,7 +12,8 @@ public enum Strategy {
     FAVOR_RETORT("Favor retort", new FavorModifierEvaluator(PotionModifier.CONCENTRATED)),
     FAVOR_MOX("Favor mox", new FavorComponentEvaluator(PotionComponent.MOX)),
     FAVOR_AGA("Favor aga", new FavorComponentEvaluator(PotionComponent.AGA)),
-    FAVOR_LYE("Favor lye", new FavorComponentEvaluator(PotionComponent.LYE));
+    FAVOR_LYE("Favor lye", new FavorComponentEvaluator(PotionComponent.LYE)),
+    FAVOR_SUM("Favor total reward", new FavorComponentEvaluator(null));
 
     private final String name;
     private final PotionOrderEvaluator evaluator;

--- a/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/BestExperienceEvaluator.java
@@ -2,23 +2,22 @@ package work.fking.masteringmixology.evaluator;
 
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class BestExperienceEvaluator implements PotionOrderEvaluator {
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
-        PotionOrder bestOrder = null;
-        var bestExperience = 0;
+    public Map<PotionOrder, Integer> evaluate(EvaluatorContext context) {
 
+        Map<PotionOrder, Integer> scores = new HashMap<>();
         for (PotionOrder order : context.orders()) {
             var potionExperience = order.potionType().experience();
             var modifierExperience = order.potionModifier().quickActionExperience();
             var totalExperience = potionExperience + modifierExperience;
 
-            if (totalExperience > bestExperience) {
-                bestOrder = order;
-                bestExperience = totalExperience;
-            }
+            scores.put(order, totalExperience);
         }
-        return bestOrder;
+        return scores;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorComponentEvaluator.java
@@ -4,6 +4,10 @@ import work.fking.masteringmixology.PotionComponent;
 import work.fking.masteringmixology.PotionOrder;
 import work.fking.masteringmixology.PotionType;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 public class FavorComponentEvaluator implements PotionOrderEvaluator {
 
     private final PotionComponent favoredComponent;
@@ -13,30 +17,18 @@ public class FavorComponentEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
-        PotionOrder bestOrder = null;
-        var bestScore = 0;
-
+    public Map<PotionOrder, Integer> evaluate(EvaluatorContext context) {
+        Map<PotionOrder, Integer> scores = new HashMap<>();
         for (var order : context.orders()) {
-            var score = computePotionScore(order.potionType());
-            if (score > bestScore) {
-                bestOrder = order;
-                bestScore = score;
-            }
+            scores.put(order, computePotionScore(order.potionType()));
         }
-        return bestOrder;
+        return scores;
     }
 
     private int computePotionScore(PotionType potionType) {
-        var score = 0;
-
-        for (var component : potionType.components()) {
-            if (component == favoredComponent) {
-                score += 3;
-            } else {
-                score++;
-            }
-        }
+        int score = 0;
+        score += 2 * potionType.getReward(favoredComponent);
+        score += Arrays.stream(PotionComponent.values()).mapToInt(potionType::getReward).sum();
         return score;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/FavorModifierEvaluator.java
@@ -3,6 +3,9 @@ package work.fking.masteringmixology.evaluator;
 import work.fking.masteringmixology.PotionModifier;
 import work.fking.masteringmixology.PotionOrder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class FavorModifierEvaluator implements PotionOrderEvaluator {
 
     private final PotionModifier modifier;
@@ -12,12 +15,15 @@ public class FavorModifierEvaluator implements PotionOrderEvaluator {
     }
 
     @Override
-    public PotionOrder evaluate(EvaluatorContext context) {
+    public Map<PotionOrder, Integer> evaluate(EvaluatorContext context) {
+        Map<PotionOrder, Integer> scores = new HashMap<>();
         for (var order : context.orders()) {
             if (order.potionModifier() == modifier) {
-                return order;
+                scores.put(order, 1);
+            } else {
+                scores.put(order, 0);
             }
         }
-        return null;
+        return scores;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
@@ -18,31 +18,13 @@ public interface PotionOrderEvaluator {
     class EvaluatorContext {
 
         private final List<PotionOrder> orders;
-        private final int lyeResin;
-        private final int agaResin;
-        private final int moxResin;
 
         public EvaluatorContext(List<PotionOrder> orders, int lyeResin, int agaResin, int moxResin) {
             this.orders = orders;
-            this.lyeResin = lyeResin;
-            this.agaResin = agaResin;
-            this.moxResin = moxResin;
         }
 
         public List<PotionOrder> orders() {
             return orders;
-        }
-
-        public int lyeResin() {
-            return lyeResin;
-        }
-
-        public int agaResin() {
-            return agaResin;
-        }
-
-        public int moxResin() {
-            return moxResin;
         }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
+++ b/src/main/java/work/fking/masteringmixology/evaluator/PotionOrderEvaluator.java
@@ -3,16 +3,17 @@ package work.fking.masteringmixology.evaluator;
 import work.fking.masteringmixology.PotionOrder;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PotionOrderEvaluator {
 
     /**
-     * Evaluates all the potion orders and determines which one should be highlighted.
+     * Evaluates all the potion orders and returns a map containing strategy scores for each order.
      *
      * @param context The context containing the potion orders and additional player related information.
-     * @return The potion order to be highlighted.
+     * @return Strategy scores for each order.
      */
-    PotionOrder evaluate(EvaluatorContext context);
+    Map<PotionOrder, Integer> evaluate(EvaluatorContext context);
 
     class EvaluatorContext {
 


### PR DESCRIPTION
Updates the highlighting scheme, highlighting each station with a different color as long as at least one order uses it. Additionally highlights potions in the player's inventory to reflect which stations they should be processed at to complete an order. This highlighting method doesn't depend on a strategy, instead relying on the player to implement small optimizations such as pathing / whether they decide to mix potions preemptively or as orders are placed.

![image](https://github.com/user-attachments/assets/b635aa54-6538-4201-b882-24ab77d82f31)

Additionally modifies the strategy implementation by replacing the evaluator's output from a single potion order to a map that scores every order based on the selected strategy. This is reflected in the game UI by displaying various "levels" of highlight; the orders that are highlighted the brightest indicate those that would generate the greatest score under the selected strategy.

Example with "favor lye" strategy:
![image](https://github.com/user-attachments/assets/6e828bd3-83ac-4b15-a2f2-9c789611b910)

- Adds a "favor total reward" strategy now that not all orders have the same total reward.
- Updates experience and reward values to reflect the game update on 10/2/2024. These are no longer tied to PotionComponents (as they are no longer simple sums of component values), but are instead generated in PotionType.