### PR TITLE
separate quick-action highlighting & potion order tracking improvements

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -52,6 +52,16 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "highlightQuickActionEvents",
+            name = "Highlight quick-action events",
+            description = "Toggles station quick-action events highlighting on or off",
+            position = 2
+    )
+    default boolean highlightQuickActionEvents() {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "stationHighlightColor",
             name = "Station color",
             description = "Configures the default station highlight color",

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -6,6 +6,8 @@ public class PotionOrder {
     private final PotionType potionType;
     private final PotionModifier potionModifier;
 
+    private boolean fulfilled;
+
     public PotionOrder(int idx, PotionType potionType, PotionModifier potionModifier) {
         this.idx = idx;
         this.potionType = potionType;
@@ -22,6 +24,14 @@ public class PotionOrder {
 
     public PotionModifier potionModifier() {
         return potionModifier;
+    }
+
+    public void setFulfilled(boolean fulfilled) {
+        this.fulfilled = fulfilled;
+    }
+
+    public boolean fulfilled() {
+        return fulfilled;
     }
 
     @Override


### PR DESCRIPTION
* Station quick-action highlighting can now be configured separately
* Improved station highlighting when multiple orders share the same potion type
* Show `(ready!)` when you finish refining a potion that fulfills an order

![{4BDA27E9-119D-42CD-80A6-9AE7AC08B814}](https://github.com/user-attachments/assets/22de9872-31c8-4859-bc0b-d8c96ddaaaa9)
