### PR TITLE
Update highlighting behavior

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -115,8 +115,8 @@ public class MasteringMixologyPlugin extends Plugin {
     private int previousAgitatorProgess;
     private int previousAlembicProgress;
 
-    private int agitatorQuickActionFlag = 0;
-    private int alembicQuickActionFlag = 0;
+    private int agitatorQuickActionTicks = 0;
+    private int alembicQuickActionTicks = 0;
 
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
@@ -324,13 +324,13 @@ public class MasteringMixologyPlugin extends Plugin {
                 unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
             }
         } else if (varbitId == VARBIT_AGITATOR_PROGRESS) {
-            if (agitatorQuickActionFlag == 2) {
+            if (agitatorQuickActionTicks == 2) {
                 // quick action was triggered two ticks ago, so it's now too late
                 unHighlightObject(AlchemyObject.AGITATOR);
-                agitatorQuickActionFlag = 0;
+                agitatorQuickActionTicks = 0;
             }
-            if (agitatorQuickActionFlag == 1) {
-                agitatorQuickActionFlag = 2;
+            if (agitatorQuickActionTicks == 1) {
+                agitatorQuickActionTicks = 2;
             }
             if (value < previousAgitatorProgess) {
                 // progress was set back due to a quick action failure
@@ -338,10 +338,10 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             previousAgitatorProgess = value;
         } else if (varbitId == VARBIT_ALEMBIC_PROGRESS) {
-            if (alembicQuickActionFlag == 1) {
+            if (alembicQuickActionTicks == 1) {
                 // quick action was triggered last tick, so it's now too late
                 unHighlightObject(AlchemyObject.ALEMBIC);
-                alembicQuickActionFlag = 0;
+                alembicQuickActionTicks = 0;
             }
             if (value < previousAlembicProgress) {
                 // progress was set back due to a quick action failure
@@ -366,16 +366,16 @@ public class MasteringMixologyPlugin extends Plugin {
         }
         if (spotAnimId == SPOT_ANIM_ALEMBIC && alembicPotionType != null) {
             highlightObject(AlchemyObject.ALEMBIC, config.stationQuickActionHighlightColor());
-            // set flag for alembic so we know to un-highlight on the next alembic update
+            // start counting ticks for alembic so we know to un-highlight on the next alembic varbit update
             // note this quick action has a 1 tick window, so we use an int that goes 0 -> 1 -> unhighlight
-            alembicQuickActionFlag = 1;
+            alembicQuickActionTicks = 1;
         }
 
         if (spotAnimId == SPOT_ANIM_AGITATOR && agitatorPotionType != null) {
             highlightObject(AlchemyObject.AGITATOR, config.stationQuickActionHighlightColor());
-            // set flag for alembic so we know to un-highlight on the next agitator update
+            // start counting ticks for agitator so we know to un-highlight on the next agitator varbit update
             // note this quick action has a 2-tick window, so we use an int that goes 0 -> 1 -> 2 -> unhighlight
-            agitatorQuickActionFlag = 1;
+            agitatorQuickActionTicks = 1;
         }
     }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -326,7 +326,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_AGITATOR_PROGRESS) {
             if (agitatorQuickActionTicks == 2) {
                 // quick action was triggered two ticks ago, so it's now too late
-                unHighlightObject(AlchemyObject.AGITATOR);
+                resetDefaultHighlight(AlchemyObject.AGITATOR);
                 agitatorQuickActionTicks = 0;
             }
             if (agitatorQuickActionTicks == 1) {
@@ -334,26 +334,26 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             if (value < previousAgitatorProgess) {
                 // progress was set back due to a quick action failure
-                unHighlightObject(AlchemyObject.AGITATOR);
+                resetDefaultHighlight(AlchemyObject.AGITATOR);
             }
             previousAgitatorProgess = value;
         } else if (varbitId == VARBIT_ALEMBIC_PROGRESS) {
             if (alembicQuickActionTicks == 1) {
                 // quick action was triggered last tick, so it's now too late
-                unHighlightObject(AlchemyObject.ALEMBIC);
+                resetDefaultHighlight(AlchemyObject.ALEMBIC);
                 alembicQuickActionTicks = 0;
             }
             if (value < previousAlembicProgress) {
                 // progress was set back due to a quick action failure
-                unHighlightObject(AlchemyObject.ALEMBIC);
+                resetDefaultHighlight(AlchemyObject.ALEMBIC);
             }
             previousAlembicProgress = value;
         } else if (varbitId == VARBIT_AGITATOR_QUICKACTION) {
             // agitator quick action was just successfully popped
-            unHighlightObject(AlchemyObject.AGITATOR);
+            resetDefaultHighlight(AlchemyObject.AGITATOR);
         } else if (varbitId == VARBIT_ALEMBIC_QUICKACTION) {
             // alembic quick action was just successfully popped
-            unHighlightObject(AlchemyObject.ALEMBIC);
+            resetDefaultHighlight(AlchemyObject.ALEMBIC);
         }
     }
 
@@ -444,6 +444,12 @@ public class MasteringMixologyPlugin extends Plugin {
 
         if (decorativeObject != null && decorativeObject.getId() == alchemyObject.objectId()) {
             highlightedObjects.put(alchemyObject, new HighlightedObject(decorativeObject, color, config.highlightBorderWidth(), config.highlightFeather()));
+        }
+    }
+
+    public void resetDefaultHighlight(AlchemyObject alchemyObject) {
+        if (config.highlightStations()) {
+            highlightObject(alchemyObject, config.stationHighlightColor());
         }
     }
 


### PR DESCRIPTION
Added a few lines that keep track of the progress of the alembic and agitator to de-highlight it under the following scenarios:

- if the quick action is successfully hit
- if the quick action is missed (so after 1 tick for the alembic and 2 ticks for the agitator)

This addresses #51 