### PR TITLE
Use RL Notification object for digweed

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -4,6 +4,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Notification;
 
 import java.awt.Color;
 
@@ -97,8 +98,8 @@ public interface MasteringMixologyConfig extends Config {
             description = "Toggles digweed notifications on or off",
             position = 5
     )
-    default boolean notifyDigWeed() {
-        return true;
+    default Notification notifyDigWeed() {
+        return Notification.ON;
     }
 
     @ConfigItem(

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -283,9 +283,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 if (config.highlightDigWeed()) {
                     highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor());
                 }
-                if (config.notifyDigWeed()) {
-                    notifier.notify("A digweed has spawned north east.");
-                }
+                notifier.notify(config.notifyDigWeed(), "A digweed has spawned north east.");
             } else {
                 unHighlightObject(AlchemyObject.DIGWEED_NORTH_EAST);
             }
@@ -294,9 +292,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 if (config.highlightDigWeed()) {
                     highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor());
                 }
-                if (config.notifyDigWeed()) {
-                    notifier.notify("A digweed has spawned south east.");
-                }
+                notifier.notify(config.notifyDigWeed(), "A digweed has spawned south east.");
             } else {
                 unHighlightObject(AlchemyObject.DIGWEED_SOUTH_EAST);
             }
@@ -305,9 +301,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 if (config.highlightDigWeed()) {
                     highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor());
                 }
-                if (config.notifyDigWeed()) {
-                    notifier.notify("A digweed has spawned south west.");
-                }
+                notifier.notify(config.notifyDigWeed(), "A digweed has spawned south west.");
             } else {
                 unHighlightObject(AlchemyObject.DIGWEED_SOUTH_WEST);
             }
@@ -316,9 +310,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 if (config.highlightDigWeed()) {
                     highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor());
                 }
-                if (config.notifyDigWeed()) {
-                    notifier.notify("A digweed has spawned north west.");
-                }
+                notifier.notify(config.notifyDigWeed(), "A digweed has spawned north west.");
             } else {
                 unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
             }


### PR DESCRIPTION
Using a Notification object instead of a boolean allows for customizable overrides.