### PR TITLE
Add modifier and Digweed to inventory overlay

### DIFF
--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -124,8 +124,7 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
 
         var potion = plugin.getNextPotion();
 
-        if (potion == null || potionType != potion.type) {
-            plugin.syncInventoryPotionsAtEndOfFrame();
+        if (potion == null) {
             return;
         }
 

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -1,17 +1,37 @@
 package work.fking.masteringmixology;
 
 import net.runelite.api.widgets.WidgetItem;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
 import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static work.fking.masteringmixology.PotionComponent.AGA;
+import static work.fking.masteringmixology.PotionComponent.LYE;
+import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public class InventoryPotionOverlay extends WidgetItemOverlay {
-
     private final MasteringMixologyPlugin plugin;
     private final MasteringMixologyConfig config;
+    private final Logger logger = LoggerFactory.getLogger(InventoryPotionOverlay.class);
+    private BufferedImage retortSprite;
+    private BufferedImage alembicSprite;
+    private BufferedImage agitatorSprite;
+    private boolean isInitialized;
+
+    @Inject
+    private SpriteManager spriteManager;
+
+    @Inject
+    private ItemManager itemManager;
 
     @Inject
     InventoryPotionOverlay(MasteringMixologyPlugin plugin, MasteringMixologyConfig config) {
@@ -20,21 +40,90 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         showOnInventory();
     }
 
+    private void initialize() {
+        retortSprite = spriteManager.getSprite(5672, 0);
+        alembicSprite = spriteManager.getSprite(5673, 0);
+        agitatorSprite = spriteManager.getSprite(5674, 0);
+    }
+
+    private void drawRecipe(Graphics2D g, char[] recipeChars, int x, int y, boolean isBlack) {
+        g.setFont(FontManager.getRunescapeSmallFont());
+        g.setColor(Color.BLACK);
+        for (char recipeChar : recipeChars) {
+            if (recipeChar == 'M') {
+                if (!isBlack) {
+                    g.setColor(Color.decode("#" + MOX.color()));
+                }
+                g.drawString("M", x, y);
+                x += 8;
+            } else if (recipeChar == 'A') {
+                if (!isBlack) {
+                    g.setColor(Color.decode("#" + AGA.color()));
+                }
+                g.drawString("A", x, y);
+                x += 7;
+            } else if (recipeChar == 'L') {
+                if (!isBlack) {
+                    g.setColor(Color.decode("#" + LYE.color()));
+                }
+                g.drawString("L", x, y);
+                x += 5;
+            }
+        }
+    }
+
     @Override
     public void renderItemOverlay(Graphics2D graphics2D, int itemId, WidgetItem widgetItem) {
         if (!plugin.isInLab() || !config.identifyPotions()) {
             return;
         }
 
-        var potion = PotionType.fromItemId(itemId);
+        if (!isInitialized) {
+            initialize();
+        }
+
+        if (PotionType.fromItemId(30020 < itemId ? itemId - 10: itemId) == null) {
+            return;
+        }
+
+        var potion = plugin.getNextPotion();
+
         if (potion == null) {
+            logger.warn("Could not get next potion");
             return;
         }
 
         var bounds = widgetItem.getCanvasBounds();
-        graphics2D.setFont(FontManager.getRunescapeSmallFont());
+        var x = bounds.x;
+        var y = bounds.y + 10;
+        var recipeChars = potion.type.recipe().toCharArray();
 
-        graphics2D.setColor(Color.WHITE);
-        graphics2D.drawString(potion.abbreviation(), bounds.x - 1, bounds.y + 15);
+        drawRecipe(graphics2D, recipeChars, x + 1, y + 1, true);
+        drawRecipe(graphics2D, recipeChars, x, y, false);
+
+        if (!potion.isModified) {
+            return;
+        }
+
+        if (potion.modifier == null) {
+            graphics2D.setFont(FontManager.getRunescapeBoldFont());
+            graphics2D.setColor(Color.BLACK);
+            graphics2D.drawString("?", x + 4, y + 18);
+            graphics2D.setColor(Color.WHITE);
+            graphics2D.drawString("?", x + 3, y + 17);
+            return;
+        }
+
+        switch (potion.modifier.alchemyObject()) {
+            case RETORT:
+                graphics2D.drawImage(retortSprite, x, y, null);
+                break;
+            case ALEMBIC:
+                graphics2D.drawImage(alembicSprite, x, y, null);
+                break;
+            case AGITATOR:
+                graphics2D.drawImage(agitatorSprite, x, y, null);
+                break;
+        }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -1,5 +1,7 @@
 package work.fking.masteringmixology;
 
+import net.runelite.api.Client;
+import net.runelite.api.SpritePixels;
 import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -10,22 +12,21 @@ import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashMap;
 
 import static work.fking.masteringmixology.PotionComponent.AGA;
 import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public class InventoryPotionOverlay extends WidgetItemOverlay {
+    private static final int RETORT_SPRITE_ID = 5672;
+    private static final int ALEMBIC_SPRITE_ID = 5673;
+    private static final int AGITATOR_SPRITE_ID = 5674;
+    private static final int DIGWEED_ITEM_ID = 30031;
+
     private final MasteringMixologyPlugin plugin;
     private final MasteringMixologyConfig config;
-    private final Logger logger = LoggerFactory.getLogger(InventoryPotionOverlay.class);
-    private BufferedImage retortSprite;
-    private BufferedImage alembicSprite;
-    private BufferedImage agitatorSprite;
-    private boolean isInitialized;
+    private final HashMap<Potion, BufferedImage> potionOverlays = new HashMap<>();
 
     @Inject
     private SpriteManager spriteManager;
@@ -34,96 +35,107 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
     private ItemManager itemManager;
 
     @Inject
+    private Client client;
+
+    @Inject
     InventoryPotionOverlay(MasteringMixologyPlugin plugin, MasteringMixologyConfig config) {
         this.plugin = plugin;
         this.config = config;
         showOnInventory();
     }
 
-    private void initialize() {
-        retortSprite = spriteManager.getSprite(5672, 0);
-        alembicSprite = spriteManager.getSprite(5673, 0);
-        agitatorSprite = spriteManager.getSprite(5674, 0);
-    }
-
     private void drawRecipe(Graphics2D g, char[] recipeChars, int x, int y, boolean isBlack) {
         g.setFont(FontManager.getRunescapeSmallFont());
         g.setColor(Color.BLACK);
+
         for (char recipeChar : recipeChars) {
             if (recipeChar == 'M') {
                 if (!isBlack) {
                     g.setColor(Color.decode("#" + MOX.color()));
                 }
+
                 g.drawString("M", x, y);
                 x += 8;
             } else if (recipeChar == 'A') {
                 if (!isBlack) {
                     g.setColor(Color.decode("#" + AGA.color()));
                 }
+
                 g.drawString("A", x, y);
                 x += 7;
             } else if (recipeChar == 'L') {
                 if (!isBlack) {
                     g.setColor(Color.decode("#" + LYE.color()));
                 }
+
                 g.drawString("L", x, y);
                 x += 5;
             }
         }
     }
 
+    private BufferedImage drawPotionOverlay(Potion potion) {
+        var image = new BufferedImage(36, 32, BufferedImage.TYPE_INT_ARGB);
+        var graphics2D = image.createGraphics();
+        var x = 0;
+        var y = 10;
+        var recipeChars = potion.type.recipe().toCharArray();
+
+        drawRecipe(graphics2D, recipeChars, x + 1, y + 1, true); // Drop shadow
+        drawRecipe(graphics2D, recipeChars, x, y, false);
+
+        if (potion.isModified) {
+            if (potion.modifier == null) {
+                graphics2D.setFont(FontManager.getRunescapeBoldFont());
+                graphics2D.setColor(Color.BLACK);
+                graphics2D.drawString("?", x + 4, y + 18); // Drop shadow
+                graphics2D.setColor(Color.WHITE);
+                graphics2D.drawString("?", x + 3, y + 17);
+            } else if (potion.modifier == PotionModifier.CONCENTRATED) {
+                graphics2D.drawImage(spriteManager.getSprite(RETORT_SPRITE_ID, 0), x, y, null);
+            } else if (potion.modifier == PotionModifier.HOMOGENOUS) {
+                graphics2D.drawImage(spriteManager.getSprite(ALEMBIC_SPRITE_ID, 0), x, y, null);
+            } else if (potion.modifier == PotionModifier.CRYSTALISED) {
+                graphics2D.drawImage(spriteManager.getSprite(AGITATOR_SPRITE_ID, 0), x, y, null);
+            }
+        }
+
+        if (!potion.hasDigweed) {
+            return image;
+        }
+
+        var pixels = client.createItemSprite(DIGWEED_ITEM_ID, 1, 1, SpritePixels.DEFAULT_SHADOW_COLOR, 0, false, 384);
+
+        if (pixels == null) {
+            return image;
+        }
+
+        var sprite = pixels.toBufferedImage();
+        graphics2D.drawImage(sprite, x + 5, y - 5, null);
+        return image;
+    }
+
     @Override
     public void renderItemOverlay(Graphics2D graphics2D, int itemId, WidgetItem widgetItem) {
-        if (!plugin.isInLab() || !config.identifyPotions()) {
-            return;
-        }
-
-        if (!isInitialized) {
-            initialize();
-        }
-
-        if (PotionType.fromItemId(30020 < itemId ? itemId - 10: itemId) == null) {
+        var potionType = PotionType.fromItemId(30020 < itemId ? itemId - 10: itemId);
+        if (!plugin.isInLab() || !config.identifyPotions() || potionType == null) {
             return;
         }
 
         var potion = plugin.getNextPotion();
 
-        if (potion == null) {
-            logger.warn("Could not get next potion");
+        if (potion == null || potionType != potion.type) {
+            plugin.syncInventoryPotionsAtEndOfFrame();
             return;
         }
 
+        if (!potionOverlays.containsKey(potion)) {
+            potionOverlays.put(potion, drawPotionOverlay(potion));
+        }
+
+        var image = potionOverlays.get(potion);
         var bounds = widgetItem.getCanvasBounds();
-        var x = bounds.x;
-        var y = bounds.y + 10;
-        var recipeChars = potion.type.recipe().toCharArray();
 
-        drawRecipe(graphics2D, recipeChars, x + 1, y + 1, true);
-        drawRecipe(graphics2D, recipeChars, x, y, false);
-
-        if (!potion.isModified) {
-            return;
-        }
-
-        if (potion.modifier == null) {
-            graphics2D.setFont(FontManager.getRunescapeBoldFont());
-            graphics2D.setColor(Color.BLACK);
-            graphics2D.drawString("?", x + 4, y + 18);
-            graphics2D.setColor(Color.WHITE);
-            graphics2D.drawString("?", x + 3, y + 17);
-            return;
-        }
-
-        switch (potion.modifier.alchemyObject()) {
-            case RETORT:
-                graphics2D.drawImage(retortSprite, x, y, null);
-                break;
-            case ALEMBIC:
-                graphics2D.drawImage(alembicSprite, x, y, null);
-                break;
-            case AGITATOR:
-                graphics2D.drawImage(agitatorSprite, x, y, null);
-                break;
-        }
+        graphics2D.drawImage(image, bounds.x, bounds.y, null);
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -24,7 +24,8 @@ public class MasteringMixologyOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
-        plugin.resetPotionIndex(); // this goes here because fuck you.
+        // resetPotionIndex needs to be called between inventory renders for the item overlay to work.
+        plugin.resetPotionIndex();
 
         for (var highlightedObject : plugin.highlightedObjects().values()) {
             modelOutlineRenderer.drawOutline(highlightedObject.object(), highlightedObject.outlineWidth(), highlightedObject.color(), highlightedObject.feather());

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -24,6 +24,8 @@ public class MasteringMixologyOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
+        plugin.resetPotionIndex(); // this goes here because fuck you.
+
         for (var highlightedObject : plugin.highlightedObjects().values()) {
             modelOutlineRenderer.drawOutline(highlightedObject.object(), highlightedObject.outlineWidth(), highlightedObject.color(), highlightedObject.feather());
         }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -1,10 +1,24 @@
 package work.fking.masteringmixology;
 
-
 import com.google.inject.Provides;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.FontID;
+import net.runelite.api.GameState;
+import net.runelite.api.InventoryID;
+import net.runelite.api.TileObject;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Item;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.events.*;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GraphicsObjectCreated;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.events.WidgetClosed;
+import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetPositionMode;
 import net.runelite.api.widgets.WidgetTextAlignment;
@@ -18,6 +32,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ColorUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
@@ -284,7 +299,7 @@ public class MasteringMixologyPlugin extends Plugin {
         var inventory = event.getItemContainer();
 
         syncInventoryPotions(inventory);
-        tryFulfillOrder();
+        tryFulfillOrders();
         tryHighlightNextStation(inventory);
     }
 
@@ -651,7 +666,7 @@ public class MasteringMixologyPlugin extends Plugin {
     private void updatePotionOrders() {
         LOGGER.debug("Updating potion orders");
         potionOrders = getPotionOrders();
-        tryFulfillOrder();
+        tryFulfillOrders();
 
         var potionOrderSorting = config.potionOrderSorting();
 
@@ -689,7 +704,7 @@ public class MasteringMixologyPlugin extends Plugin {
         LOGGER.debug("adding resin text {} at {} with color {}", amount, x, color);
     }
 
-    private void tryFulfillOrder() {
+    private void tryFulfillOrders() {
         for (var potion : inventoryPotions) {
             if (potion == null) {
                 continue;

--- a/src/main/java/work/fking/masteringmixology/Potion.java
+++ b/src/main/java/work/fking/masteringmixology/Potion.java
@@ -1,7 +1,8 @@
 package work.fking.masteringmixology;
+import java.util.Objects;
 
 public class Potion {
-    public PotionType type;
+    public final PotionType type;
     public PotionModifier modifier = null;
     public boolean isModified;
     public boolean hasDigweed = false;
@@ -11,34 +12,30 @@ public class Potion {
         this.isModified = isModified;
     }
 
-    public void setModifier(PotionModifier modifier) {
+    public void modify(PotionModifier modifier) {
         this.modifier = modifier;
         isModified = true;
     }
 
-    public String toString() {
-        var s = type.abbreviation();
-
-        if (isModified) {
-            if (modifier == null) {
-                s += "???";
-            } else if (modifier == PotionModifier.HOMOGENOUS) {
-                s += "HOM";
-            } else if (modifier == PotionModifier.CONCENTRATED) {
-                s += "CON";
-            } else if (modifier == PotionModifier.CRYSTALISED) {
-                s += "CRY";
-            }
-        } else {
-            s += "___";
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
 
-        if (hasDigweed) {
-            s += "D";
-        } else {
-            s += "_";
+        if (o instanceof Potion) {
+            Potion potion = (Potion) o;
+            return isModified == potion.isModified &&
+                    hasDigweed == potion.hasDigweed &&
+                    type == potion.type &&
+                    Objects.equals(modifier, potion.modifier);
         }
 
-        return s;
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, modifier, isModified, hasDigweed);
     }
 }

--- a/src/main/java/work/fking/masteringmixology/Potion.java
+++ b/src/main/java/work/fking/masteringmixology/Potion.java
@@ -1,0 +1,44 @@
+package work.fking.masteringmixology;
+
+public class Potion {
+    public PotionType type;
+    public PotionModifier modifier = null;
+    public boolean isModified;
+    public boolean hasDigweed = false;
+
+    public Potion(PotionType type, boolean isModified) {
+        this.type = type;
+        this.isModified = isModified;
+    }
+
+    public void setModifier(PotionModifier modifier) {
+        this.modifier = modifier;
+        isModified = true;
+    }
+
+    public String toString() {
+        var s = type.abbreviation();
+
+        if (isModified) {
+            if (modifier == null) {
+                s += "???";
+            } else if (modifier == PotionModifier.HOMOGENOUS) {
+                s += "HOM";
+            } else if (modifier == PotionModifier.CONCENTRATED) {
+                s += "CON";
+            } else if (modifier == PotionModifier.CRYSTALISED) {
+                s += "CRY";
+            }
+        } else {
+            s += "___";
+        }
+
+        if (hasDigweed) {
+            s += "D";
+        } else {
+            s += "_";
+        }
+
+        return s;
+    }
+}


### PR DESCRIPTION
I know this is a very large PR but it was just easy to do all of these improvements at the same time. However, I am open to breaking this PR up if you only want some of it.

# Rationale

This PR makes inventory tags work for modified potions and with Digweed. It was clear that for this feature to work, there would need to be a virtual representation of the potions in the players inventory. Though maintaining this representation throughout the mini game adds some complexity, it was also able to improve functionality and reduce complexity in other parts areas. Fulfilling orders and highlight stations are now based on what is in the players inventory and are able to update on inventory change.

# Strategy

The best strategy for points is to fulfill 3 orders at a time but the best strategy for exp for irons and broke mains is to make every type of potion except triples and then hand in multiple at a time while missing some orders. This PR supports that strategy by allowing you to see when you are not longer holding completed orders after handing in potions.

# Features

- Shows modifier for potion in inventory
- Shows if a potion is enhanced with Digweed
- Updates completed orders on inventory change
- Highlights 1 or multiple stations based on orders and what potion is first in the inventory
- If modifier or Digweed is unknown from logging out. You can inspect the potion to add overlay information.
- Supports reordering potions in the inventory

![2024-10-14_16-58-42](https://github.com/user-attachments/assets/90705f05-3dec-47e9-bffd-b17e56b5c75a)