### PR TITLE
Add colored inventory tags

### DIFF
--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -1,15 +1,24 @@
 package work.fking.masteringmixology;
 
 import net.runelite.api.widgets.WidgetItem;
+import net.runelite.api.ItemID;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+
+import static work.fking.masteringmixology.PotionComponent.AGA;
+import static work.fking.masteringmixology.PotionComponent.LYE;
+import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public class InventoryPotionOverlay extends WidgetItemOverlay {
-
+    private static final int MODIFIED_POTION_ID_DIFF = ItemID.MIXALOT_30030 - ItemID.MIXALOT;
+    private final HashMap<PotionType, BufferedImage> imageCache = new HashMap<>();
     private final MasteringMixologyPlugin plugin;
     private final MasteringMixologyConfig config;
 
@@ -20,21 +29,68 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         showOnInventory();
     }
 
+    public void clearCache() {
+        imageCache.clear();
+    }
+
     @Override
     public void renderItemOverlay(Graphics2D graphics2D, int itemId, WidgetItem widgetItem) {
-        if (!plugin.isInLab() || !config.identifyPotions()) {
+        if (!plugin.isInLab() || config.inventoryPotionTagType() == InventoryPotionTagType.NONE) {
             return;
         }
 
-        var potion = PotionType.fromItemId(itemId);
+        var potion = PotionType.fromItemId(itemId <= ItemID.MIXALOT ? itemId : itemId - MODIFIED_POTION_ID_DIFF);
+
         if (potion == null) {
             return;
         }
 
+        if (!imageCache.containsKey(potion)) {
+            imageCache.put(potion, createRecipeImage(potion));
+        }
+
         var bounds = widgetItem.getCanvasBounds();
+        graphics2D.drawImage(imageCache.get(potion), bounds.x, bounds.y, null);
+    }
+
+    private BufferedImage createRecipeImage(PotionType potion) {
+        // Font measurements come from: graphics2D.getFontMetrics(FontManager.getRunescapeSmallFont())
+        var image = new BufferedImage(25, 13, BufferedImage.TYPE_INT_ARGB);
+        var graphics2D = image.createGraphics();
+        drawRecipe(graphics2D, potion, 1, 13, Color.BLACK); // Drop shadow
+
+        if (config.inventoryPotionTagType() == InventoryPotionTagType.COLORED) {
+            drawRecipe(graphics2D, potion, 0, 12, null);
+            return image;
+        }
+
+        drawRecipe(graphics2D, potion, 0, 12, Color.WHITE);
+        return image;
+    }
+
+    private void drawRecipe(Graphics2D graphics2D, PotionType potion, int x, int y, @Nullable Color color) {
         graphics2D.setFont(FontManager.getRunescapeSmallFont());
 
-        graphics2D.setColor(Color.WHITE);
-        graphics2D.drawString(potion.abbreviation(), bounds.x - 1, bounds.y + 15);
+        if (color != null) {
+            graphics2D.setColor(color);
+            graphics2D.drawString(potion.abbreviation(), x, y);
+            return;
+        }
+
+        for (var component : potion.components()) {
+            if (component == MOX) {
+                graphics2D.setColor(Color.decode("#" + MOX.color()));
+                graphics2D.drawString("M", x, y);
+                x += 8;
+            } else if (component == AGA) {
+                graphics2D.setColor(Color.decode("#" + AGA.color()));
+                graphics2D.drawString("A", x, y);
+                x += 7;
+            } else if (component == LYE) {
+                graphics2D.setColor(Color.decode("#" + LYE.color()));
+                graphics2D.drawString("L", x, y);
+                x += 5;
+            }
+        }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -1,7 +1,6 @@
 package work.fking.masteringmixology;
 
 import net.runelite.api.widgets.WidgetItem;
-import net.runelite.api.ItemID;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.WidgetItemOverlay;
 
@@ -9,16 +8,8 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.util.HashMap;
-
-import static work.fking.masteringmixology.PotionComponent.AGA;
-import static work.fking.masteringmixology.PotionComponent.LYE;
-import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public class InventoryPotionOverlay extends WidgetItemOverlay {
-    private static final int MODIFIED_POTION_ID_DIFF = ItemID.MIXALOT_30030 - ItemID.MIXALOT;
-    private final HashMap<PotionType, BufferedImage> imageCache = new HashMap<>();
     private final MasteringMixologyPlugin plugin;
     private final MasteringMixologyConfig config;
 
@@ -29,43 +20,30 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         showOnInventory();
     }
 
-    public void clearCache() {
-        imageCache.clear();
-    }
-
     @Override
     public void renderItemOverlay(Graphics2D graphics2D, int itemId, WidgetItem widgetItem) {
         if (!plugin.isInLab() || config.inventoryPotionTagType() == InventoryPotionTagType.NONE) {
             return;
         }
 
-        var potion = PotionType.fromItemId(itemId <= ItemID.MIXALOT ? itemId : itemId - MODIFIED_POTION_ID_DIFF);
+        var potion = PotionType.fromItemId(itemId);
 
         if (potion == null) {
             return;
         }
 
-        if (!imageCache.containsKey(potion)) {
-            imageCache.put(potion, createRecipeImage(potion));
-        }
-
         var bounds = widgetItem.getCanvasBounds();
-        graphics2D.drawImage(imageCache.get(potion), bounds.x, bounds.y, null);
-    }
+        var x = bounds.x;
+        var y = bounds.y + 13;
 
-    private BufferedImage createRecipeImage(PotionType potion) {
-        // Font measurements come from: graphics2D.getFontMetrics(FontManager.getRunescapeSmallFont())
-        var image = new BufferedImage(25, 13, BufferedImage.TYPE_INT_ARGB);
-        var graphics2D = image.createGraphics();
-        drawRecipe(graphics2D, potion, 1, 13, Color.BLACK); // Drop shadow
+        drawRecipe(graphics2D, potion, x + 1, y + 1, Color.BLACK); // Drop shadow
 
         if (config.inventoryPotionTagType() == InventoryPotionTagType.COLORED) {
-            drawRecipe(graphics2D, potion, 0, 12, null);
-            return image;
+            drawRecipe(graphics2D, potion, x, y, null);
+            return;
         }
 
-        drawRecipe(graphics2D, potion, 0, 12, Color.WHITE);
-        return image;
+        drawRecipe(graphics2D, potion, x, y, Color.WHITE);
     }
 
     private void drawRecipe(Graphics2D graphics2D, PotionType potion, int x, int y, @Nullable Color color) {
@@ -78,19 +56,9 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         }
 
         for (var component : potion.components()) {
-            if (component == MOX) {
-                graphics2D.setColor(Color.decode("#" + MOX.color()));
-                graphics2D.drawString("M", x, y);
-                x += 8;
-            } else if (component == AGA) {
-                graphics2D.setColor(Color.decode("#" + AGA.color()));
-                graphics2D.drawString("A", x, y);
-                x += 7;
-            } else if (component == LYE) {
-                graphics2D.setColor(Color.decode("#" + LYE.color()));
-                graphics2D.drawString("L", x, y);
-                x += 5;
-            }
+            graphics2D.setColor(Color.decode("#" + component.color()));
+            graphics2D.drawString(String.valueOf(component.character()), x, y);
+            x += graphics2D.getFontMetrics().charWidth(component.character());
         }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionTagType.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionTagType.java
@@ -1,0 +1,7 @@
+package work.fking.masteringmixology;
+
+public enum InventoryPotionTagType {
+    NONE,
+    COLORED,
+    WHITE,
+}

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -23,6 +23,16 @@ public interface MasteringMixologyConfig extends Config {
     String HIGHLIGHTS = "Highlights";
 
     @ConfigItem(
+            keyName = "inventoryPotionTags",
+            name = "Inventory Potion Tags",
+            description = "How potions should be tagged in the inventory",
+            position = 1
+    )
+    default InventoryPotionTagType inventoryPotionTagType() {
+        return InventoryPotionTagType.COLORED;
+    }
+
+    @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
             description = "Determines how potion orders are sorted in the interface",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -29,7 +29,7 @@ public interface MasteringMixologyConfig extends Config {
             position = 1
     )
     default InventoryPotionTagType inventoryPotionTagType() {
-        return InventoryPotionTagType.COLORED;
+        return InventoryPotionTagType.WHITE;
     }
 
     @ConfigItem(

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -73,16 +73,6 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "identifyPotions",
-            name = "Identify potions",
-            description = "Identify potions in your inventory",
-            position = 2
-    )
-    default boolean identifyPotions() {
-        return true;
-    }
-
-    @ConfigItem(
             keyName = "displayResin",
             name = "Display resin amount",
             description = "Display total resin amounts",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,10 +186,6 @@ public class MasteringMixologyPlugin extends Plugin {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 
-        if (event.getKey().equals("inventoryPotionTags")) {
-            potionOverlay.clearCache();
-        }
-
         if (!config.highlightStations()) {
             unHighlightAllStations();
         }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -217,7 +217,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
         // Find the first potion item and highlight its station
         for (var item : inventory.getItems()) {
-            var potionType = PotionType.fromItemId(item.getId());
+            var potionType = PotionType.fromItemId(item.getId(), false);
 
             if (potionType == null) {
                 continue;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -217,9 +217,9 @@ public class MasteringMixologyPlugin extends Plugin {
 
         // Find the first potion item and highlight its station
         for (var item : inventory.getItems()) {
-            var potionType = PotionType.fromItemId(item.getId(), false);
+            var potionType = PotionType.fromItemId(item.getId());
 
-            if (potionType == null) {
+            if (potionType == null || potionType.modifiedItemId() == item.getId()) {
                 continue;
             }
             for (var order : potionOrders) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,6 +186,10 @@ public class MasteringMixologyPlugin extends Plugin {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 
+        if (event.getKey().equals("inventoryPotionTags")) {
+            potionOverlay.clearCache();
+        }
+
         if (!config.highlightStations()) {
             unHighlightAllStations();
         }

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -56,16 +56,6 @@ public enum PotionType {
         return ITEM_MAP.get(itemId);
     }
 
-    public static PotionType fromItemId(int itemId, boolean isModified) {
-        var potionType = ITEM_MAP.get(itemId);
-
-        if (potionType == null || isModified != (potionType.modifiedItemId() == itemId)) {
-            return null;
-        }
-
-        return potionType;
-    }
-
     public static PotionType fromIdx(int potionTypeId) {
         if (potionTypeId < 0 || potionTypeId >= TYPES.length) {
             return null;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -11,16 +11,16 @@ import static work.fking.masteringmixology.PotionComponent.LYE;
 import static work.fking.masteringmixology.PotionComponent.MOX;
 
 public enum PotionType {
-    MAMMOTH_MIGHT_MIX(ItemID.MAMMOTHMIGHT_MIX, 1900, MOX, MOX, MOX),
-    MYSTIC_MANA_AMALGAM(ItemID.MYSTIC_MANA_AMALGAM, 2150, MOX, MOX, AGA),
-    MARLEYS_MOONLIGHT(ItemID.MARLEYS_MOONLIGHT, 2400, MOX, MOX, LYE),
-    ALCO_AUGMENTATOR(ItemID.ALCOAUGMENTATOR, 1900, AGA, AGA, AGA),
-    AZURE_AURA_MIX(ItemID.AZURE_AURA_MIX, 2650, AGA, AGA, MOX),
-    AQUALUX_AMALGAM(ItemID.AQUALUX_AMALGAM, 2900, AGA, LYE, AGA),
-    LIPLACK_LIQUOR(ItemID.LIPLACK_LIQUOR, 1900, LYE, LYE, LYE),
-    MEGALITE_LIQUID(ItemID.MEGALITE_LIQUID, 3150, MOX, LYE, LYE),
-    ANTI_LEECH_LOTION(ItemID.ANTILEECH_LOTION, 3400, AGA, LYE, LYE),
-    MIXALOT(ItemID.MIXALOT, 3650, MOX, AGA, LYE);
+    MAMMOTH_MIGHT_MIX(ItemID.MAMMOTHMIGHT_MIX, ItemID.MAMMOTHMIGHT_MIX_30021, 1900, MOX, MOX, MOX),
+    MYSTIC_MANA_AMALGAM(ItemID.MYSTIC_MANA_AMALGAM, ItemID.MYSTIC_MANA_AMALGAM_30022, 2150, MOX, MOX, AGA),
+    MARLEYS_MOONLIGHT(ItemID.MARLEYS_MOONLIGHT, ItemID.MARLEYS_MOONLIGHT_30023, 2400, MOX, MOX, LYE),
+    ALCO_AUGMENTATOR(ItemID.ALCOAUGMENTATOR, ItemID.ALCOAUGMENTATOR_30024, 1900, AGA, AGA, AGA),
+    AZURE_AURA_MIX(ItemID.AZURE_AURA_MIX, ItemID.AZURE_AURA_MIX_30026, 2650, AGA, AGA, MOX),
+    AQUALUX_AMALGAM(ItemID.AQUALUX_AMALGAM, ItemID.AQUALUX_AMALGAM_30025, 2900, AGA, LYE, AGA),
+    LIPLACK_LIQUOR(ItemID.LIPLACK_LIQUOR, ItemID.LIPLACK_LIQUOR_30027, 1900, LYE, LYE, LYE),
+    MEGALITE_LIQUID(ItemID.MEGALITE_LIQUID, ItemID.MEGALITE_LIQUID_30029, 3150, MOX, LYE, LYE),
+    ANTI_LEECH_LOTION(ItemID.ANTILEECH_LOTION, ItemID.ANTILEECH_LOTION_30028, 3400, AGA, LYE, LYE),
+    MIXALOT(ItemID.MIXALOT, ItemID.MIXALOT_30030, 3650, MOX, AGA, LYE);
 
     public static final PotionType[] TYPES = PotionType.values();
 
@@ -30,19 +30,22 @@ public enum PotionType {
         var builder = new ImmutableMap.Builder<Integer, PotionType>();
         for (var p : PotionType.values()) {
             builder.put(p.itemId(), p);
+            builder.put(p.modifiedItemId(), p);
         }
         ITEM_MAP = builder.build();
     }
 
     private final int itemId;
+    private final int modifiedItemId;
     private final String recipe;
     private final String abbreviation;
     private final int experience;
     private final PotionComponent[] components;
 
 
-    PotionType(int itemId, int experience, PotionComponent... components) {
+    PotionType(int itemId, int modifiedItemId, int experience, PotionComponent... components) {
         this.itemId = itemId;
+        this.modifiedItemId = modifiedItemId;
         this.recipe = colorizeRecipe(components);
         this.experience = experience;
         this.components = components;
@@ -75,6 +78,10 @@ public enum PotionType {
 
     public int itemId() {
         return itemId;
+    }
+
+    public int modifiedItemId() {
+        return modifiedItemId;
     }
 
     public String recipe() {

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -56,6 +56,16 @@ public enum PotionType {
         return ITEM_MAP.get(itemId);
     }
 
+    public static PotionType fromItemId(int itemId, boolean isModified) {
+        var potionType = ITEM_MAP.get(itemId);
+
+        if (potionType == null || isModified != (potionType.modifiedItemId() == itemId)) {
+            return null;
+        }
+
+        return potionType;
+    }
+
     public static PotionType fromIdx(int potionTypeId) {
         if (potionTypeId < 0 || potionTypeId >= TYPES.length) {
             return null;


### PR DESCRIPTION
- Options to change inventory tag type
- Colored inventory tags
- Applies tags to modified potions now

<img width="243" alt="Screenshot 2024-10-16 at 7 42 19 AM" src="https://github.com/user-attachments/assets/33fce015-b996-4fd0-8f95-5a51045cb11f">
