### PR TITLE
Add Concentrate Last order sorting

### DIFF
--- a/src/main/java/work/fking/masteringmixology/PotionComparators.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComparators.java
@@ -1,0 +1,24 @@
+package work.fking.masteringmixology;
+
+import java.util.Comparator;
+
+public class PotionComparators {
+
+    // Sort by modifier, in the order CRYSTALISED > HOMOGENOUS > CONCENTRATED
+    // And then by PotionType name alphabetically
+    public static Comparator<PotionOrder> byStation() {
+        return Comparator.comparingInt((PotionOrder order) -> {
+                    switch (order.potionModifier()) {
+                        case CRYSTALISED:
+                            return 0;
+                        case HOMOGENOUS:
+                            return 1;
+                        case CONCENTRATED:
+                            return 2;
+                        default:
+                            return Integer.MAX_VALUE;
+                    }
+                })
+                .thenComparing(order -> order.potionType().name());
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -4,10 +4,19 @@ import java.util.Comparator;
 
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
-    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal())),
-    CONCENTRATE_LAST("Concentrate Last", Comparator.comparing((PotionOrder order) ->
-                    order.potionModifier() == PotionModifier.CONCENTRATED ? 1 : 0)
-            .thenComparing(order -> order.potionModifier().ordinal()));
+    // Sort by modifier, in the order CRYSTALISED > HOMOGENOUS > CONCENTRATED
+    BY_STATION("By station", Comparator.comparingInt(order -> {
+        switch (order.potionModifier()) {
+            case CRYSTALISED:
+                return 0;
+            case HOMOGENOUS:
+                return 1;
+            case CONCENTRATED:
+                return 2;
+            default:
+                return Integer.MAX_VALUE;
+        }
+    }));
 
     private final String name;
     private final Comparator<PotionOrder> comparator;

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -4,7 +4,10 @@ import java.util.Comparator;
 
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
-    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal()));
+    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal())),
+    CONCENTRATE_LAST("Concentrate Last", Comparator.comparing((PotionOrder order) ->
+                    order.potionModifier() == PotionModifier.CONCENTRATED ? 1 : 0)
+            .thenComparing(order -> order.potionModifier().ordinal()));
 
     private final String name;
     private final Comparator<PotionOrder> comparator;

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -4,22 +4,7 @@ import java.util.Comparator;
 
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
-    // Sort by modifier, in the order CRYSTALISED > HOMOGENOUS > CONCENTRATED
-    BY_STATION("By station", Comparator
-            .comparingInt((PotionOrder order) -> {
-                switch (order.potionModifier()) {
-                    case CRYSTALISED:
-                        return 0;
-                    case HOMOGENOUS:
-                        return 1;
-                    case CONCENTRATED:
-                        return 2;
-                    default:
-                        return Integer.MAX_VALUE;
-                }
-            })
-            .thenComparing(order -> order.potionType().name()) // Secondary sorting by PotionType name alphabetically
-    );
+    BY_STATION("By station", PotionComparators.byStation());
 
     private final String name;
     private final Comparator<PotionOrder> comparator;

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -5,18 +5,21 @@ import java.util.Comparator;
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
     // Sort by modifier, in the order CRYSTALISED > HOMOGENOUS > CONCENTRATED
-    BY_STATION("By station", Comparator.comparingInt(order -> {
-        switch (order.potionModifier()) {
-            case CRYSTALISED:
-                return 0;
-            case HOMOGENOUS:
-                return 1;
-            case CONCENTRATED:
-                return 2;
-            default:
-                return Integer.MAX_VALUE;
-        }
-    }));
+    BY_STATION("By station", Comparator
+            .comparingInt((PotionOrder order) -> {
+                switch (order.potionModifier()) {
+                    case CRYSTALISED:
+                        return 0;
+                    case HOMOGENOUS:
+                        return 1;
+                    case CONCENTRATED:
+                        return 2;
+                    default:
+                        return Integer.MAX_VALUE;
+                }
+            })
+            .thenComparing(order -> order.potionType().name()) // Secondary sorting by PotionType name alphabetically
+    );
 
     private final String name;
     private final Comparator<PotionOrder> comparator;


### PR DESCRIPTION
Since the concentrate modifier requires you to spam click, this option sorts Concentrate potions last to reduce accidental miss-clicks when processing multiple orders.

This fixes #79 

This is a very small change adding the following PotionOrderSorting enum:
```java
CONCENTRATE_LAST("Concentrate Last", Comparator.comparing((PotionOrder order) ->
                order.potionModifier() == PotionModifier.CONCENTRATED ? 1 : 0)
        .thenComparing(order -> order.potionModifier().ordinal()));
```

Wondering if we can change it to go in the order 
Crystalize>Homogenise>Concentrate as it's currently doing 
Homogenise>Crystalize>Concentrate 
Which forces you to walk further than you should? Please give input on this