### PR TITLE
Added ability to blacklist potions

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -174,7 +174,7 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = STRATEGY,
-            keyName = "ignoreBlacklistWhenMAL",
+            keyName = "ignoreBlacklistForMixalot",
             name = "Ignore Blacklist For Mixalot Orders",
             description = "Do not skip any potions if the order contains a Mixalot potion.",
             position = 2

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -133,6 +133,14 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "potionsToSkip",
+            name = "Potions To Skip",
+            description = "Type the potion recipes you want to skip, separated by commas",
+            position = 8
+    )
+    default String potionsToSkip() { return ""; }
+
+    @ConfigItem(
             section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -168,7 +168,9 @@ public interface MasteringMixologyConfig extends Config {
             description = "Select the potions you want to skip, hold ctrl to select multiple",
             position = 1
     )
-    default Set<PotionType> potionBlacklist() { return Collections.emptySet(); }
+    default Set<PotionType> potionBlacklist() {
+        return Collections.emptySet();
+    }
 
     @ConfigItem(
             section = STRATEGY,
@@ -177,5 +179,7 @@ public interface MasteringMixologyConfig extends Config {
             description = "Do not skip any potions if the order contains a Mixalot potion.",
             position = 2
     )
-    default boolean ignoreBlacklistForMixalot() { return true; }
+    default boolean ignoreBlacklistForMixalot() {
+        return true;
+    }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -7,6 +7,8 @@ import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Notification;
 
 import java.awt.Color;
+import java.util.Collections;
+import java.util.Set;
 
 import static work.fking.masteringmixology.MasteringMixologyConfig.CONFIG_GROUP;
 
@@ -162,17 +164,17 @@ public interface MasteringMixologyConfig extends Config {
     @ConfigItem(
             section = STRATEGY,
             keyName = "potionsToSkip",
-            name = "Potions To Skip",
-            description = "Type the potion recipes you want to skip, separated by commas",
+            name = "Blacklist",
+            description = "Choose the potions you want to skip, hold ctrl to select multiple",
             position = 1
     )
-    default String potionsToSkip() { return ""; }
+    default Set<PotionType> potionsToSkip() { return Collections.emptySet(); }
 
     @ConfigItem(
             section = STRATEGY,
             keyName = "ignoreSkipWhenMAL",
-            name = "Ignore When MAL is in Order",
-            description = "Do not skip potions if the order contains a Mixalot potion.",
+            name = "Ignore When Mixalot is in Order",
+            description = "Do not skip any potions if the order contains a Mixalot potion.",
             position = 2
     )
     default boolean ignoreSkipWhenMAL() { return true; }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -163,19 +163,19 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = STRATEGY,
-            keyName = "potionsToSkip",
+            keyName = "potionBlacklist",
             name = "Blacklist",
-            description = "Choose the potions you want to skip, hold ctrl to select multiple",
+            description = "Select the potions you want to skip, hold ctrl to select multiple",
             position = 1
     )
-    default Set<PotionType> potionsToSkip() { return Collections.emptySet(); }
+    default Set<PotionType> potionBlacklist() { return Collections.emptySet(); }
 
     @ConfigItem(
             section = STRATEGY,
-            keyName = "ignoreSkipWhenMAL",
-            name = "Ignore When Mixalot is in Order",
+            keyName = "ignoreBlacklistWhenMAL",
+            name = "Ignore Blacklist For Mixalot Orders",
             description = "Do not skip any potions if the order contains a Mixalot potion.",
             position = 2
     )
-    default boolean ignoreSkipWhenMAL() { return true; }
+    default boolean ignoreBlacklistForMixalot() { return true; }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -22,6 +22,13 @@ public interface MasteringMixologyConfig extends Config {
     )
     String HIGHLIGHTS = "Highlights";
 
+    @ConfigSection(
+            name = "Strategy",
+            description = "Strategy related configuration",
+            position = 20
+    )
+    String STRATEGY = "Strategy";
+
     @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
@@ -133,14 +140,6 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "potionsToSkip",
-            name = "Potions To Skip",
-            description = "Type the potion recipes you want to skip, separated by commas",
-            position = 8
-    )
-    default String potionsToSkip() { return ""; }
-
-    @ConfigItem(
             section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",
@@ -159,4 +158,22 @@ public interface MasteringMixologyConfig extends Config {
     default int highlightFeather() {
         return 1;
     }
+
+    @ConfigItem(
+            section = STRATEGY,
+            keyName = "potionsToSkip",
+            name = "Potions To Skip",
+            description = "Type the potion recipes you want to skip, separated by commas",
+            position = 1
+    )
+    default String potionsToSkip() { return ""; }
+
+    @ConfigItem(
+            section = STRATEGY,
+            keyName = "ignoreSkipWhenMAL",
+            name = "Ignore When MAL is in Order",
+            description = "Do not skip potions if the order contains a Mixalot potion.",
+            position = 2
+    )
+    default boolean ignoreSkipWhenMAL() { return true; }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -557,7 +558,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
         // Sort the orders so that blacklisted potions are at the bottom
         if (useBlacklistForOrder(potionOrders)) {
-            potionOrders.sort((o1, o2) -> Boolean.compare(isPotionBlacklisted(o1.potionType()), isPotionBlacklisted(o2.potionType())));
+            potionOrders.sort(Comparator.comparing(order -> isPotionBlacklisted(order.potionType())));
         }
 
         // Trigger a fake varbit update to force run the clientscript proc
@@ -665,12 +666,7 @@ public class MasteringMixologyPlugin extends Plugin {
     }
 
     private static boolean doesOrderContainMixalot(List<PotionOrder> orders) {
-        for (PotionOrder order : orders) {
-            if (order.potionType() == PotionType.MIXALOT) {
-                return true;
-            }
-        }
-        return false;
+        return orders.stream().anyMatch(order -> order.potionType() == PotionType.MIXALOT);
     }
 
     public static class HighlightedObject {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,7 +186,7 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         String key = event.getKey();
-        if (key.equals("potionOrderSorting") || key.equals("potionsToSkip") || key.equals("enableStrategy")) {
+        if (key.equals("potionOrderSorting") || key.equals("potionsToSkip")) {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -401,6 +401,14 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
+        boolean containsMAL = false;
+        for (PotionOrder order : potionOrders) {
+            if (order.potionType() == PotionType.MIXALOT) {
+                containsMAL = config.ignoreSkipWhenMAL();
+                break;
+            }
+        }
+
         for (int i = 0; i < potionOrders.size(); i++) {
             var order = potionOrders.get(i);
 
@@ -414,7 +422,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             var builder = new StringBuilder();
 
-            boolean skipPotion = shouldSkipPotion(order.potionType());
+            boolean skipPotion = !containsMAL && shouldSkipPotion(order.potionType());
             if (skipPotion) {
                 builder.append("<col=999999>");
             }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -419,25 +419,23 @@ public class MasteringMixologyPlugin extends Plugin {
             if (orderGraphic.getType() != WidgetType.GRAPHIC || orderText.getType() != WidgetType.TEXT) {
                 continue;
             }
-            var builder = new StringBuilder();
 
             boolean skipPotion = useBlacklist && isPotionBlacklisted(order.potionType());
-            if (skipPotion) {
-                builder.append("<col=999999>");
-            }
-            builder.append(orderText.getText());
-            if (skipPotion) {
-                builder.append("</col>");
-            }
+            String newOrderText = orderText.getText();
 
+            newOrderText += " (";
             if (order.fulfilled()) {
-                builder.append(" (<col=00ff00>done!</col>)");
-            } else if (skipPotion) {
-                builder.append(" (SKIP)");
+                newOrderText += skipPotion ? "done!" : colorText("done!", "00ff00");
             } else {
-                builder.append(" (").append(order.potionType().recipe()).append(")");
+                PotionType potionType = order.potionType();
+                newOrderText += skipPotion ? potionType.abbreviation() : potionType.recipe();
             }
-            orderText.setText(builder.toString());
+            newOrderText += ")";
+
+            if (skipPotion) {
+                newOrderText = colorText(newOrderText, "999999");
+            }
+            orderText.setText(newOrderText);
 
             if (i != order.idx()) {
                 // update component position
@@ -449,6 +447,10 @@ public class MasteringMixologyPlugin extends Plugin {
                 orderText.revalidate();
             }
         }
+    }
+
+    private String colorText(String text, String colorCode) {
+        return "<col=" + colorCode + ">" + text + "</col>";
     }
 
     private void appendResins(Widget baseWidget) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -39,7 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-
 import static work.fking.masteringmixology.AlchemyObject.AGA_LEVER;
 import static work.fking.masteringmixology.AlchemyObject.LYE_LEVER;
 import static work.fking.masteringmixology.AlchemyObject.MOX_LEVER;
@@ -126,7 +125,6 @@ public class MasteringMixologyPlugin extends Plugin {
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
     }
-    private List<String> potionsToSkip = new ArrayList<>();
 
     public boolean isInLab() {
         return inLab;
@@ -205,10 +203,6 @@ public class MasteringMixologyPlugin extends Plugin {
             highlightLevers();
         } else {
             unHighlightLevers();
-        }
-
-        if (key.equals("potionsToSkip")) {
-            updatePotionsToSkip();
         }
     }
 
@@ -479,7 +473,6 @@ public class MasteringMixologyPlugin extends Plugin {
 
         LOGGER.debug("initialize plugin");
         inLab = true;
-        updatePotionsToSkip();
         updatePotionOrders();
         highlightLevers();
         tryHighlightNextStation();
@@ -660,25 +653,8 @@ public class MasteringMixologyPlugin extends Plugin {
         }
     }
 
-    private void updatePotionsToSkip() {
-        potionsToSkip.clear();
-
-        String potionsToSkipString = config.potionsToSkip().toLowerCase();
-        String[] potions = potionsToSkipString.split(",");
-        for (String potion : potions) {
-            potionsToSkip.add(sortChars(potion.trim()));
-        }
-    }
-
     private boolean shouldSkipPotion(PotionType potionType) {
-        String recipe = potionType.rawRecipe().toLowerCase();
-        return potionsToSkip.contains(sortChars(recipe));
-    }
-
-    private static String sortChars(String s) {
-        char[] chars = s.toCharArray();
-        Arrays.sort(chars);
-        return new String(chars);
+        return config.potionsToSkip().contains(potionType);
     }
 
     public static class HighlightedObject {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -561,6 +561,9 @@ public class MasteringMixologyPlugin extends Plugin {
             LOGGER.debug("Sorted orders: {}", potionOrders);
         }
 
+        // Sort the orders so that skipped potions are at the bottom
+        potionOrders.sort((o1, o2) -> Boolean.compare(shouldSkipPotion(o1.potionType()), shouldSkipPotion(o2.potionType())));
+
         // Trigger a fake varbit update to force run the clientscript proc
         var varbitType = client.getVarbit(VARBIT_POTION_ORDER_1);
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -32,7 +32,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.awt.Color;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 
 import static work.fking.masteringmixology.AlchemyObject.AGA_LEVER;
 import static work.fking.masteringmixology.AlchemyObject.LYE_LEVER;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -5,6 +5,7 @@ import net.runelite.api.ItemID;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static work.fking.masteringmixology.PotionComponent.AGA;
 import static work.fking.masteringmixology.PotionComponent.LYE;
@@ -36,7 +37,6 @@ public enum PotionType {
 
     private final int itemId;
     private final String recipe;
-    private final String rawRecipe;
     private final String abbreviation;
     private final int experience;
     private final PotionComponent[] components;
@@ -45,7 +45,6 @@ public enum PotionType {
     PotionType(int itemId, int experience, PotionComponent... components) {
         this.itemId = itemId;
         this.recipe = colorizeRecipe(components);
-        this.rawRecipe = buildRecipe(components);
         this.experience = experience;
         this.components = components;
         this.abbreviation = "" + components[0].character() + components[1].character() + components[2].character();
@@ -71,13 +70,6 @@ public enum PotionType {
                 + colorizeRecipeComponent(components[2]);
     }
 
-    private static String buildRecipe(PotionComponent[] components) {
-        if (components.length != 3) {
-            throw new IllegalArgumentException("Invalid potion components: " + Arrays.toString(components));
-        }
-        return ("" + components[0].character() + components[1].character() + components[2].character());
-    }
-
     private static String colorizeRecipeComponent(PotionComponent component) {
         return "<col=" + component.color() + ">" + component.character() + "</col>";
     }
@@ -90,10 +82,6 @@ public enum PotionType {
         return recipe;
     }
 
-    public String rawRecipe() {
-        return rawRecipe;
-    }
-
     public int experience() {
         return experience;
     }
@@ -104,5 +92,17 @@ public enum PotionType {
 
     public String abbreviation() {
         return abbreviation;
+    }
+
+    // Used to display the potion type in the config UI
+    @Override
+    public String toString() {
+        return abbreviation() + " - " + toTitleCase(super.toString());
+    }
+
+    private static String toTitleCase(String s) {
+        return Arrays.stream(s.toLowerCase().split("_"))
+                .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1))
+                .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -86,9 +86,13 @@ public enum PotionType {
         return itemId;
     }
 
-    public String recipe() { return recipe; }
+    public String recipe() {
+        return recipe;
+    }
 
-    public String rawRecipe() { return rawRecipe; }
+    public String rawRecipe() {
+        return rawRecipe;
+    }
 
     public int experience() {
         return experience;

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -36,6 +36,7 @@ public enum PotionType {
 
     private final int itemId;
     private final String recipe;
+    private final String rawRecipe;
     private final String abbreviation;
     private final int experience;
     private final PotionComponent[] components;
@@ -44,6 +45,7 @@ public enum PotionType {
     PotionType(int itemId, int experience, PotionComponent... components) {
         this.itemId = itemId;
         this.recipe = colorizeRecipe(components);
+        this.rawRecipe = buildRecipe(components);
         this.experience = experience;
         this.components = components;
         this.abbreviation = "" + components[0].character() + components[1].character() + components[2].character();
@@ -69,6 +71,13 @@ public enum PotionType {
                 + colorizeRecipeComponent(components[2]);
     }
 
+    private static String buildRecipe(PotionComponent[] components) {
+        if (components.length != 3) {
+            throw new IllegalArgumentException("Invalid potion components: " + Arrays.toString(components));
+        }
+        return ("" + components[0].character() + components[1].character() + components[2].character());
+    }
+
     private static String colorizeRecipeComponent(PotionComponent component) {
         return "<col=" + component.color() + ">" + component.character() + "</col>";
     }
@@ -77,9 +86,9 @@ public enum PotionType {
         return itemId;
     }
 
-    public String recipe() {
-        return recipe;
-    }
+    public String recipe() { return recipe; }
+
+    public String rawRecipe() { return rawRecipe; }
 
     public int experience() {
         return experience;


### PR DESCRIPTION
Allows the user to set specific potions for skipping and reflect this in the UI.
Should aid users who are trying to balance their resins by skipping designated potions.

![image](https://github.com/user-attachments/assets/ca1bd998-7963-4040-bd57-46a584062f38)

Looks like this addresses #71 