### PR TITLE
Add Goal Tracking Infobox panel

### DIFF
--- a/src/main/java/work/fking/masteringmixology/Goal.java
+++ b/src/main/java/work/fking/masteringmixology/Goal.java
@@ -1,0 +1,86 @@
+package work.fking.masteringmixology;
+
+import net.runelite.api.Client;
+
+import java.util.EnumMap;
+
+public class Goal {
+    private RewardItem rewardItem;
+    private double overallProgress = 0.0;
+    private int itemsAffordable = 0;
+    private int rewardQuantity = 1;
+
+    /*
+     * Whenever we recalculate the goal, we will create a new ComponentData object for each component for caching
+     */
+    private final EnumMap<PotionComponent, ComponentData> componentDataMap = new EnumMap<>(PotionComponent.class);
+
+    public Goal(RewardItem rewardItem) {
+        this.rewardItem = rewardItem;
+    }
+
+    public RewardItem getRewardItem() {
+        return rewardItem;
+    }
+
+    public double getOverallProgress() {
+        return overallProgress;
+    }
+
+    public int getItemsAffordable() {
+        return itemsAffordable;
+    }
+
+    public int getRewardQuantity() {
+        return rewardQuantity;
+    }
+
+    public ComponentData getComponentData(PotionComponent component) {
+        return componentDataMap.get(component);
+    }
+
+    public void recalculate(MasteringMixologyConfig config, Client client) {
+        rewardItem = config.selectedReward();
+        rewardQuantity = rewardItem.isRepeatable() ? config.rewardQuantity() : 1;
+
+        // Create the component data for each component
+        for (PotionComponent component : PotionComponent.values()) {
+            int currentAmount = client.getVarpValue(component.resinVarpId());
+            int baseGoalAmount = rewardItem.componentCost(component);
+            componentDataMap.put(component, new ComponentData(currentAmount, baseGoalAmount, rewardQuantity));
+        }
+
+        // Calculate the amount of items affordable based on the component with the lowest affordable amount
+        int minAffordable = componentDataMap.values().stream()
+                .mapToInt(data -> data.affordableAmount)
+                .min()
+                .orElse(0);
+        itemsAffordable = Math.min(minAffordable, rewardQuantity);
+
+        // Overall progress is the average of all component progress
+        overallProgress = componentDataMap.values().stream()
+                .mapToDouble(data -> data.percentageToGoal)
+                .average()
+                .orElse(0.0);
+    }
+
+    public static class ComponentData {
+        final int currentAmount;
+        final int goalAmount;
+        final double percentageToGoal;
+        final int affordableAmount;
+
+        ComponentData(int currentAmount, int baseGoalAmount, int rewardQuantity) {
+            this.currentAmount = currentAmount;
+            this.goalAmount = baseGoalAmount * rewardQuantity;
+
+            if (goalAmount == 0) {
+                this.percentageToGoal = 1.0;
+                this.affordableAmount = rewardQuantity;
+            } else {
+                this.percentageToGoal = Math.min((double) currentAmount / goalAmount, 1.0);
+                this.affordableAmount = currentAmount / baseGoalAmount;
+            }
+        }
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -42,7 +42,6 @@ class GoalInfoBoxOverlay extends OverlayPanel {
 
     private final PanelComponent topPanel = new PanelComponent();
 
-    private final Map<Integer, BufferedImage> rewardIconCache = new HashMap<>();
     private final EnumMap<PotionComponent, BufferedImage> componentSpriteCache = new EnumMap<>(PotionComponent.class);
 
     @Inject
@@ -103,7 +102,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .orientation(ComponentOrientation.VERTICAL)
                 .build();
 
-        ImageComponent rewardImageComponent = new ImageComponent(getRewardImage(rewardItem));
+        ImageComponent rewardImageComponent = new ImageComponent(itemManager.getImage(rewardItem.itemId()));
         var topInfoSplit = SplitComponent.builder()
                 .first(rewardImageComponent)
                 .second(textSplit)
@@ -143,10 +142,6 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .build();
 
         panelComponent.getChildren().add(progressBarSplit);
-    }
-
-    private BufferedImage getRewardImage(RewardItem rewardItem) {
-        return rewardIconCache.computeIfAbsent(rewardItem.itemId(), itemManager::getImage);
     }
 
     private BufferedImage getComponentSprite(PotionComponent component) {

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -23,8 +23,6 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
 
 class GoalInfoBoxOverlay extends OverlayPanel {
     private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0");

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -23,6 +23,8 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 
 class GoalInfoBoxOverlay extends OverlayPanel {
     private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0");
@@ -40,6 +42,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
 
     private final PanelComponent topPanel = new PanelComponent();
 
+    private final Map<Integer, BufferedImage> rewardIconCache = new HashMap<>();
     private final EnumMap<PotionComponent, BufferedImage> componentSpriteCache = new EnumMap<>(PotionComponent.class);
 
     @Inject
@@ -100,7 +103,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .orientation(ComponentOrientation.VERTICAL)
                 .build();
 
-        ImageComponent rewardImageComponent = new ImageComponent(itemManager.getImage(rewardItem.itemId()));
+        ImageComponent rewardImageComponent = new ImageComponent(getRewardImage(rewardItem));
         var topInfoSplit = SplitComponent.builder()
                 .first(rewardImageComponent)
                 .second(textSplit)
@@ -140,6 +143,10 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .build();
 
         panelComponent.getChildren().add(progressBarSplit);
+    }
+
+    private BufferedImage getRewardImage(RewardItem rewardItem) {
+        return rewardIconCache.computeIfAbsent(rewardItem.itemId(), itemManager::getImage);
     }
 
     private BufferedImage getComponentSprite(PotionComponent component) {

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -81,7 +81,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
             goalAmountText = QuantityFormatter.quantityToStackSize(goal.getItemsAffordable()) + "/" + QuantityFormatter.quantityToStackSize(goal.getRewardQuantity());
         }
 
-        final LineComponent topLine = LineComponent.builder()
+        var topLine = LineComponent.builder()
                 .left(rewardItem.itemName())
                 .leftFont(FontManager.getRunescapeFont())
                 .right(goalAmountText)
@@ -89,7 +89,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .build();
 
         // Build the bottom line with the overall progress percentage
-        final LineComponent bottomLine = LineComponent.builder()
+        var bottomLine = LineComponent.builder()
                 .left("Progress:")
                 .leftFont(FontManager.getRunescapeFont())
                 .right(DECIMAL_FORMAT.format(goal.getOverallProgress() * 100) + "%")
@@ -97,14 +97,14 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                 .rightColor(goal.getOverallProgress() >= 1 ? Color.GREEN : Color.WHITE)
                 .build();
 
-        final SplitComponent textSplit = SplitComponent.builder()
+        var textSplit = SplitComponent.builder()
                 .first(topLine)
                 .second(bottomLine)
                 .orientation(ComponentOrientation.VERTICAL)
                 .build();
 
-        final ImageComponent rewardImageComponent = new ImageComponent(getRewardImage(rewardItem));
-        final SplitComponent topInfoSplit = SplitComponent.builder()
+        ImageComponent rewardImageComponent = new ImageComponent(getRewardImage(rewardItem));
+        var topInfoSplit = SplitComponent.builder()
                 .first(rewardImageComponent)
                 .second(textSplit)
                 .orientation(ComponentOrientation.HORIZONTAL)
@@ -127,15 +127,15 @@ class GoalInfoBoxOverlay extends OverlayPanel {
     private void createProgressBar(Goal goal, PotionComponent component) {
         Goal.ComponentData data = goal.getComponentData(component);
 
-        final ImageComponent imageComponent = new ImageComponent(getComponentSprite(component));
-        final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
+        ImageComponent imageComponent = new ImageComponent(getComponentSprite(component));
+        ProgressBarComponent progressBarComponent = new ProgressBarComponent();
         progressBarComponent.setForegroundColor(component.color());
         progressBarComponent.setBackgroundColor(PROGRESS_BAR_BACKGROUND_COLOR);
         progressBarComponent.setValue(data.percentageToGoal * 100);
         progressBarComponent.setLeftLabel(QuantityFormatter.quantityToStackSize(data.currentAmount));
         progressBarComponent.setRightLabel(QuantityFormatter.quantityToStackSize(data.goalAmount));
 
-        final SplitComponent progressBarSplit = SplitComponent.builder()
+        var progressBarSplit = SplitComponent.builder()
                 .first(imageComponent)
                 .second(progressBarComponent)
                 .orientation(ComponentOrientation.HORIZONTAL)

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -1,0 +1,200 @@
+package work.fking.masteringmixology;
+
+import net.runelite.api.Client;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.ComponentOrientation;
+import net.runelite.client.ui.overlay.components.ImageComponent;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.PanelComponent;
+import net.runelite.client.ui.overlay.components.ProgressBarComponent;
+import net.runelite.client.ui.overlay.components.SplitComponent;
+import net.runelite.client.util.ImageUtil;
+import net.runelite.client.util.QuantityFormatter;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+class GoalInfoBoxOverlay extends OverlayPanel {
+    private static final int BORDER_SIZE = 3;
+    private static final int VERTICAL_GAP = 2;
+    private static final int ICON_AND_GOAL_GAP = 5;
+    private static final Rectangle TOP_PANEL_BORDER = new Rectangle(2, 0, 4, 4);
+    private static final int COMPONENT_SPRITE_SIZE = 16;
+
+    private final Client client;
+    private final MasteringMixologyPlugin plugin;
+    private final MasteringMixologyConfig config;
+    private final ItemManager itemManager;
+    private final SpriteManager spriteManager;
+
+    private final PanelComponent topPanel = new PanelComponent();
+
+    private final EnumMap<PotionComponent, ComponentData> componentDataMap = new EnumMap<>(PotionComponent.class);
+    private double overallProgress = 0.0;
+    private RewardItem rewardItem;
+
+    private final Map<Integer, BufferedImage> rewardIconCache = new HashMap<>();
+    private final EnumMap<PotionComponent, BufferedImage> componentSpriteCache = new EnumMap<>(PotionComponent.class);
+
+    private boolean dataDirty = true;
+
+    @Inject
+    GoalInfoBoxOverlay(Client client, MasteringMixologyPlugin plugin, MasteringMixologyConfig config,
+                       ItemManager itemManager, SpriteManager spriteManager) {
+        super(plugin);
+        this.client = client;
+        this.plugin = plugin;
+        this.config = config;
+        this.itemManager = itemManager;
+        this.spriteManager = spriteManager;
+
+        panelComponent.setBorder(new Rectangle(BORDER_SIZE, BORDER_SIZE, BORDER_SIZE, BORDER_SIZE));
+        panelComponent.setGap(new Point(0, VERTICAL_GAP));
+        topPanel.setBorder(TOP_PANEL_BORDER);
+        topPanel.setBackgroundColor(null);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        // Recalculate the data before checking if the overlay should be displayed
+        if (dataDirty) {
+            recalculateData();
+        }
+
+        if (rewardItem == RewardItem.NONE || !plugin.isInLabRegion()) {
+            return null;
+        }
+
+        // Clear the panel components
+        topPanel.getChildren().clear();
+
+        // Set the font for the panel
+        graphics.setFont(FontManager.getRunescapeSmallFont());
+
+        // Build the top display with the reward item and overall progress
+        final LineComponent topLine = LineComponent.builder()
+                .left(rewardItem.itemName())
+                .leftFont(FontManager.getRunescapeFont())
+                .build();
+
+        final LineComponent bottomLine = LineComponent.builder()
+                .left("Progress:")
+                .leftFont(FontManager.getRunescapeFont())
+                .right((int) (overallProgress * 100) + "%")
+                .rightFont(FontManager.getRunescapeFont())
+                .rightColor(overallProgress >= 1 ? Color.GREEN : Color.WHITE)
+                .build();
+
+        final SplitComponent textSplit = SplitComponent.builder()
+                .first(topLine)
+                .second(bottomLine)
+                .orientation(ComponentOrientation.VERTICAL)
+                .build();
+
+        final ImageComponent rewardImageComponent = new ImageComponent(getRewardImage());
+        final SplitComponent topInfoSplit = SplitComponent.builder()
+                .first(rewardImageComponent)
+                .second(textSplit)
+                .orientation(ComponentOrientation.HORIZONTAL)
+                .gap(new Point(ICON_AND_GOAL_GAP, 0))
+                .build();
+
+        topPanel.getChildren().add(topInfoSplit);
+        panelComponent.getChildren().add(topPanel);
+
+        if (config.showResinProgressBars()) {
+            // Add the progress bars in order: MOX, AGA, LYE, PotionComponent order is not the same
+            createProgressBar(PotionComponent.MOX);
+            createProgressBar(PotionComponent.AGA);
+            createProgressBar(PotionComponent.LYE);
+        }
+
+        return super.render(graphics);
+    }
+
+    public void markDataAsDirty() {
+        this.dataDirty = true;
+    }
+
+    private void recalculateData() {
+        rewardItem = config.selectedReward();
+
+        double totalPercentage = 0.0;
+        totalPercentage += getAndCalculateComponentData(PotionComponent.MOX, MasteringMixologyPlugin.VARP_MOX_RESIN);
+        totalPercentage += getAndCalculateComponentData(PotionComponent.AGA, MasteringMixologyPlugin.VARP_AGA_RESIN);
+        totalPercentage += getAndCalculateComponentData(PotionComponent.LYE, MasteringMixologyPlugin.VARP_LYE_RESIN);
+        overallProgress = totalPercentage / PotionComponent.values().length;
+
+        dataDirty = false;
+    }
+
+    private double getAndCalculateComponentData(PotionComponent component, int varp) {
+        int currentAmount = client.getVarpValue(varp);
+        int goalAmount = rewardItem.componentCost(component);
+        double percentage = goalAmount == 0 ? 1.0 : Math.min((double) currentAmount / goalAmount, 1.0);
+
+        ComponentData data = new ComponentData(currentAmount, goalAmount, percentage);
+        componentDataMap.put(component, data);
+
+        return percentage;
+    }
+
+    private void createProgressBar(PotionComponent component) {
+        ComponentData data = componentDataMap.get(component);
+
+        final ImageComponent imageComponent = new ImageComponent(getComponentSprite(component));
+        final ProgressBarComponent progressBarComponent = new ProgressBarComponent();
+        progressBarComponent.setForegroundColor(Color.decode("#" + component.color()));
+        progressBarComponent.setBackgroundColor(new Color(61, 56, 49));
+        progressBarComponent.setValue(data.percentage * 100d);
+        progressBarComponent.setLeftLabel(QuantityFormatter.quantityToStackSize(data.currentAmount));
+        progressBarComponent.setRightLabel(QuantityFormatter.quantityToStackSize(data.goalAmount));
+
+        final SplitComponent progressBarSplit = SplitComponent.builder()
+                .first(imageComponent)
+                .second(progressBarComponent)
+                .orientation(ComponentOrientation.HORIZONTAL)
+                .gap(new Point(ICON_AND_GOAL_GAP, 0))
+                .build();
+
+        panelComponent.getChildren().add(progressBarSplit);
+    }
+
+    private BufferedImage getRewardImage() {
+        return rewardIconCache.computeIfAbsent(rewardItem.itemId(), itemManager::getImage);
+    }
+
+    private BufferedImage getComponentSprite(PotionComponent component) {
+        return componentSpriteCache.computeIfAbsent(component, comp -> {
+            BufferedImage sprite = spriteManager.getSprite(comp.spriteId(), 0);
+            if (sprite != null) {
+                BufferedImage resizedImage = ImageUtil.resizeImage(sprite, COMPONENT_SPRITE_SIZE, COMPONENT_SPRITE_SIZE, true);
+                return ImageUtil.resizeCanvas(resizedImage, COMPONENT_SPRITE_SIZE, COMPONENT_SPRITE_SIZE);
+            }
+            return null;
+        });
+    }
+
+    private static class ComponentData {
+        final int currentAmount;
+        final int goalAmount;
+        final double percentage;
+
+        ComponentData(int currentAmount, int goalAmount, double percentage) {
+            this.currentAmount = currentAmount;
+            this.goalAmount = goalAmount;
+            this.percentage = percentage;
+        }
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -67,7 +67,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
 
         setPosition(OverlayPosition.TOP_RIGHT);
         setPriority(PRIORITY_MED);
-        panelComponent.setPreferredSize(new Dimension(200, 0));
+        panelComponent.setPreferredSize(new Dimension(250, 0));
         panelComponent.setBorder(new Rectangle(BORDER_SIZE, BORDER_SIZE, BORDER_SIZE, BORDER_SIZE));
         panelComponent.setGap(new Point(0, VERTICAL_GAP));
 

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -56,7 +56,7 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         }
 
         for (var component : potion.components()) {
-            graphics2D.setColor(Color.decode("#" + component.color()));
+            graphics2D.setColor(component.color());
             graphics2D.drawString(String.valueOf(component.character()), x, y);
             x += graphics2D.getFontMetrics().charWidth(component.character());
         }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -5,6 +5,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Notification;
+import net.runelite.client.config.Range;
 
 import java.awt.Color;
 
@@ -172,12 +173,27 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = REWARD_TRACKING,
-            keyName = "showResinProgressBars",
-            name = "Show Resin Progress Bars",
-            description = "Toggle to display or hide the resin progress bars in the goal overlay",
+            keyName = "rewardQuantity",
+            name = "Reward Quantity",
+            description = "Set the quantity for repeatable rewards",
             position = 2
     )
-    default boolean showResinProgressBars() {
+    @Range(
+            min = 1,
+            max = 100000
+    )
+    default int rewardQuantity() {
+        return 1;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "showResinBars",
+            name = "Show Resin Bars",
+            description = "Toggle to display or hide the resin progress bars",
+            position = 3
+    )
+    default boolean showResinBars() {
         return true;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -151,4 +151,33 @@ public interface MasteringMixologyConfig extends Config {
     default int highlightFeather() {
         return 1;
     }
+
+    @ConfigSection(
+            name = "Reward Tracking",
+            description = "Track your progress towards rewards",
+            position = 13
+    )
+    String REWARD_TRACKING = "RewardTracking";
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "selectedReward",
+            name = "Selected Reward",
+            description = "Select a reward to track resin for",
+            position = 1
+    )
+    default RewardItem selectedReward() {
+        return RewardItem.NONE;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "showResinProgressBars",
+            name = "Show Resin Progress Bars",
+            description = "Toggle to display or hide the resin progress bars in the goal overlay",
+            position = 2
+    )
+    default boolean showResinProgressBars() {
+        return true;
+    }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -27,7 +27,6 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
-import net.runelite.client.util.ColorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,7 +215,7 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
         }
 
-        if (event.getKey().equals("selectedReward") || event.getKey().equals("fullProgressBarBehavior")) {
+        if (event.getKey().equals("selectedReward") || event.getKey().equals("rewardQuantity") || event.getKey().equals("progressDisplayMode") || event.getKey().equals("showResinBars")) {
             goalInfoBoxOverlay.markDataAsDirty();
         }
 
@@ -536,9 +535,9 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
-        highlightObject(LYE_LEVER, Color.decode("#" + LYE.color()));
-        highlightObject(AGA_LEVER, Color.decode("#" + AGA.color()));
-        highlightObject(MOX_LEVER, Color.decode("#" + MOX.color()));
+        highlightObject(LYE_LEVER, LYE.color());
+        highlightObject(AGA_LEVER, AGA.color());
+        highlightObject(MOX_LEVER, MOX.color());
     }
 
     private void unHighlightLevers() {
@@ -569,7 +568,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private void addResinText(Widget widget, int x, int varp, PotionComponent component) {
         var amount = client.getVarpValue(varp);
-        var color = ColorUtil.fromHex(component.color()).getRGB();
+        var color = component.color().getRGB();
 
         widget.setText(amount + "")
               .setTextShadowed(true)

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -156,6 +156,10 @@ public class MasteringMixologyPlugin extends Plugin {
         overlayManager.add(overlay);
         overlayManager.add(potionOverlay);
         overlayManager.add(goalInfoBoxOverlay);
+
+        if (client.getGameState() == GameState.LOGGED_IN) {
+            clientThread.invokeLater(this::initialize);
+        }
     }
 
     @Override

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -215,7 +215,7 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
         }
 
-        if (event.getKey().equals("selectedReward") || event.getKey().equals("rewardQuantity") || event.getKey().equals("progressDisplayMode") || event.getKey().equals("showResinBars")) {
+        if (event.getKey().equals("selectedReward") || event.getKey().equals("rewardQuantity") || event.getKey().equals("showResinBars")) {
             goalInfoBoxOverlay.markDataAsDirty();
         }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -127,6 +127,8 @@ public class MasteringMixologyPlugin extends Plugin {
     private int agitatorQuickActionTicks = 0;
     private int alembicQuickActionTicks = 0;
 
+    private final Goal goal = new Goal(RewardItem.NONE);
+
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
     }
@@ -225,7 +227,7 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         if (event.getKey().equals("selectedReward") || event.getKey().equals("rewardQuantity") || event.getKey().equals("showResinBars")) {
-            goalInfoBoxOverlay.markDataAsDirty();
+            recalculateGoalData();
         }
 
         if (config.highlightLevers()) {
@@ -381,7 +383,7 @@ public class MasteringMixologyPlugin extends Plugin {
             // alembic quick action was just successfully popped
             resetStationHighlight(AlchemyObject.ALEMBIC);
         } else if (varpId == VARP_MOX_RESIN || varpId == VARP_AGA_RESIN || varpId == VARP_LYE_RESIN) {
-            goalInfoBoxOverlay.markDataAsDirty();
+            recalculateGoalData();
         }
     }
 
@@ -671,6 +673,14 @@ public class MasteringMixologyPlugin extends Plugin {
         } else {
             return null;
         }
+    }
+
+    public Goal getGoal() {
+        return goal;
+    }
+
+    private void recalculateGoalData() {
+        goal.recalculate(config, client);
     }
 
     public static class HighlightedObject {

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,16 +1,18 @@
 package work.fking.masteringmixology;
 
 public enum PotionComponent {
-    AGA('A', "00e676"),
-    LYE('L', "e91e63"),
-    MOX('M', "03a9f4");
+    AGA('A', "00e676", 5667),
+    LYE('L', "e91e63", 5668),
+    MOX('M', "03a9f4", 5666);
 
     private final char character;
     private final String color;
+    private final int spriteId;
 
-    PotionComponent(char character, String color) {
+    PotionComponent(char character, String color, int spriteId) {
         this.character = character;
         this.color = color;
+        this.spriteId = spriteId;
     }
 
     public char character() {
@@ -19,5 +21,9 @@ public enum PotionComponent {
 
     public String color() {
         return color;
+    }
+
+    public int spriteId() {
+        return spriteId;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -8,12 +8,14 @@ public enum PotionComponent {
     LYE('L', "e91e63", 5668, MasteringMixologyPlugin.VARP_LYE_RESIN);
 
     private final char character;
+    private final String colorCode;
     private final Color color;
     private final int spriteId;
     private final int resinVarpId;
 
     PotionComponent(char character, String colorCode, int spriteId, int resinVarpId) {
         this.character = character;
+        this.colorCode = colorCode;
         this.color = Color.decode("#" + colorCode);
         this.spriteId = spriteId;
         this.resinVarpId = resinVarpId;
@@ -21,6 +23,10 @@ public enum PotionComponent {
 
     public char character() {
         return character;
+    }
+
+    public String colorCode() {
+        return colorCode;
     }
 
     public Color color() {

--- a/src/main/java/work/fking/masteringmixology/PotionComponent.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComponent.java
@@ -1,29 +1,37 @@
 package work.fking.masteringmixology;
 
+import java.awt.Color;
+
 public enum PotionComponent {
-    AGA('A', "00e676", 5667),
-    LYE('L', "e91e63", 5668),
-    MOX('M', "03a9f4", 5666);
+    MOX('M', "03a9f4", 5666, MasteringMixologyPlugin.VARP_MOX_RESIN),
+    AGA('A', "00e676", 5667, MasteringMixologyPlugin.VARP_AGA_RESIN),
+    LYE('L', "e91e63", 5668, MasteringMixologyPlugin.VARP_LYE_RESIN);
 
     private final char character;
-    private final String color;
+    private final Color color;
     private final int spriteId;
+    private final int resinVarpId;
 
-    PotionComponent(char character, String color, int spriteId) {
+    PotionComponent(char character, String colorCode, int spriteId, int resinVarpId) {
         this.character = character;
-        this.color = color;
+        this.color = Color.decode("#" + colorCode);
         this.spriteId = spriteId;
+        this.resinVarpId = resinVarpId;
     }
 
     public char character() {
         return character;
     }
 
-    public String color() {
+    public Color color() {
         return color;
     }
 
     public int spriteId() {
         return spriteId;
+    }
+
+    public int resinVarpId() {
+        return resinVarpId;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -73,7 +73,7 @@ public enum PotionType {
     }
 
     private static String colorizeRecipeComponent(PotionComponent component) {
-        return "<col=" + component.color() + ">" + component.character() + "</col>";
+        return "<col=" + component.colorCode() + ">" + component.character() + "</col>";
     }
 
     public int itemId() {

--- a/src/main/java/work/fking/masteringmixology/RewardItem.java
+++ b/src/main/java/work/fking/masteringmixology/RewardItem.java
@@ -6,27 +6,29 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum RewardItem {
-    NONE("None", 0, 0, 0, 0),
-    APPRENTICE_POTION_PACK("Apprentice Potion Pack", ItemID.APPRENTICE_POTION_PACK, 420, 70, 30),
-    ADEPT_POTION_PACK("Adept Potion Pack", ItemID.ADEPT_POTION_PACK, 180, 440, 70),
-    EXPERT_POTION_PACK("Expert Potion Pack", ItemID.EXPERT_POTION_PACK, 410, 320, 480),
-    PRESCRIPTION_GOGGLES("Prescription Goggles", ItemID.PRESCRIPTION_GOGGLES, 8600, 7000, 9350),
-    ALCHEMIST_LABCOAT("Alchemist Labcoat", ItemID.ALCHEMIST_LABCOAT, 2250, 2800, 3700),
-    ALCHEMIST_PANTS("Alchemist Pants", ItemID.ALCHEMIST_PANTS, 2250, 2800, 3700),
-    ALCHEMIST_GLOVES("Alchemist Gloves", ItemID.ALCHEMIST_GLOVES, 2250, 2800, 3700),
-    REAGENT_POUCH("Reagent Pouch", ItemID.REAGENT_POUCH, 13800, 11200, 15100),
-    POTION_STORAGE("Potion Storage", ItemID.POTION_STORAGE, 7750, 6300, 8950),
-    CHUGGING_BARREL("Chugging Barrel", ItemID.CHUGGING_BARREL, 17250, 14000, 18600),
-    ALCHEMISTS_AMULET("Alchemist's Amulet", ItemID.ALCHEMISTS_AMULET, 6900, 5650, 7400),
-    ALDARIUM("Aldarium", ItemID.ALDARIUM, 80, 60, 90);
+    NONE("None", 0, false, 0, 0, 0),
+    APPRENTICE_POTION_PACK("Apprentice Potion Pack", ItemID.APPRENTICE_POTION_PACK, true, 420, 70, 30),
+    ADEPT_POTION_PACK("Adept Potion Pack", ItemID.ADEPT_POTION_PACK, true, 180, 440, 70),
+    EXPERT_POTION_PACK("Expert Potion Pack", ItemID.EXPERT_POTION_PACK, true, 410, 320, 480),
+    PRESCRIPTION_GOGGLES("Prescription Goggles", ItemID.PRESCRIPTION_GOGGLES, false, 8600, 7000, 9350),
+    ALCHEMIST_LABCOAT("Alchemist Labcoat", ItemID.ALCHEMIST_LABCOAT, false, 2250, 2800, 3700),
+    ALCHEMIST_PANTS("Alchemist Pants", ItemID.ALCHEMIST_PANTS, false, 2250, 2800, 3700),
+    ALCHEMIST_GLOVES("Alchemist Gloves", ItemID.ALCHEMIST_GLOVES, false, 2250, 2800, 3700),
+    REAGENT_POUCH("Reagent Pouch", ItemID.REAGENT_POUCH, false, 13800, 11200, 15100),
+    POTION_STORAGE("Potion Storage", ItemID.POTION_STORAGE, false, 7750, 6300, 8950),
+    CHUGGING_BARREL("Chugging Barrel", ItemID.CHUGGING_BARREL, false, 17250, 14000, 18600),
+    ALCHEMISTS_AMULET("Alchemist's Amulet", ItemID.ALCHEMISTS_AMULET, false, 6900, 5650, 7400),
+    ALDARIUM("Aldarium", ItemID.ALDARIUM, true, 80, 60, 90);
 
     private final String itemName;
     private final int itemId;
+    private final boolean repeatable;
     private final Map<PotionComponent, Integer> componentCost = new HashMap<>();
 
-    RewardItem(String itemName, int itemId, int moxResinCost, int agaResinCost, int lyeResinCost) {
+    RewardItem(String itemName, int itemId, boolean repeatable, int moxResinCost, int agaResinCost, int lyeResinCost) {
         this.itemName = itemName;
         this.itemId = itemId;
+        this.repeatable = repeatable;
         this.componentCost.put(PotionComponent.MOX, moxResinCost);
         this.componentCost.put(PotionComponent.AGA, agaResinCost);
         this.componentCost.put(PotionComponent.LYE, lyeResinCost);
@@ -38,6 +40,10 @@ public enum RewardItem {
 
     public int itemId() {
         return itemId;
+    }
+
+    public boolean isRepeatable() {
+        return repeatable;
     }
 
     public int componentCost(PotionComponent component) {

--- a/src/main/java/work/fking/masteringmixology/RewardItem.java
+++ b/src/main/java/work/fking/masteringmixology/RewardItem.java
@@ -23,15 +23,15 @@ public enum RewardItem {
     private final String itemName;
     private final int itemId;
     private final boolean repeatable;
-    private final Map<PotionComponent, Integer> componentCost = new HashMap<>();
+    private final Integer[] componentCost = new Integer[PotionComponent.values().length];
 
     RewardItem(String itemName, int itemId, boolean repeatable, int moxResinCost, int agaResinCost, int lyeResinCost) {
         this.itemName = itemName;
         this.itemId = itemId;
         this.repeatable = repeatable;
-        this.componentCost.put(PotionComponent.MOX, moxResinCost);
-        this.componentCost.put(PotionComponent.AGA, agaResinCost);
-        this.componentCost.put(PotionComponent.LYE, lyeResinCost);
+        this.componentCost[PotionComponent.MOX.ordinal()] = moxResinCost;
+        this.componentCost[PotionComponent.AGA.ordinal()] = agaResinCost;
+        this.componentCost[PotionComponent.LYE.ordinal()] = lyeResinCost;
     }
 
     public String itemName() {
@@ -47,6 +47,6 @@ public enum RewardItem {
     }
 
     public int componentCost(PotionComponent component) {
-        return componentCost.get(component);
+        return componentCost[component.ordinal()];
     }
 }

--- a/src/main/java/work/fking/masteringmixology/RewardItem.java
+++ b/src/main/java/work/fking/masteringmixology/RewardItem.java
@@ -1,0 +1,52 @@
+package work.fking.masteringmixology;
+
+import net.runelite.api.ItemID;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("unused") // The items are used in the config
+public enum RewardItem {
+    NONE("None", 0, 0, 0, 0),
+
+    APPRENTICE_POTION_PACK("Apprentice Potion Pack", ItemID.APPRENTICE_POTION_PACK, 420, 70, 30),
+    ADEPT_POTION_PACK("Adept Potion Pack", ItemID.ADEPT_POTION_PACK, 180, 440, 70),
+    EXPERT_POTION_PACK("Expert Potion Pack", ItemID.EXPERT_POTION_PACK, 410, 320, 480),
+    PRESCRIPTION_GOGGLES("Prescription Goggles", ItemID.PRESCRIPTION_GOGGLES, 8600, 7000, 9350),
+    ALCHEMIST_LABCOAT("Alchemist Labcoat", ItemID.ALCHEMIST_LABCOAT, 2250, 2800, 3700),
+    ALCHEMIST_PANTS("Alchemist Pants", ItemID.ALCHEMIST_PANTS, 2250, 2800, 3700),
+    ALCHEMIST_GLOVES("Alchemist Gloves", ItemID.ALCHEMIST_GLOVES, 2250, 2800, 3700),
+    REAGENT_POUCH("Reagent Pouch", ItemID.REAGENT_POUCH, 13800, 11200, 15100),
+    POTION_STORAGE("Potion Storage", ItemID.POTION_STORAGE, 7750, 6300, 8950),
+    CHUGGING_BARREL("Chugging Barrel", ItemID.CHUGGING_BARREL, 17250, 14000, 18600),
+    ALCHEMISTS_AMULET("Alchemist's Amulet", ItemID.ALCHEMISTS_AMULET, 6900, 5650, 7400),
+    ALDARIUM("Aldarium", ItemID.ALDARIUM, 80, 60, 90);
+
+    private final String itemName;
+    private final int itemId;
+    private final Map<PotionComponent, Integer> componentCost = new HashMap<>();
+
+    RewardItem(String itemName, int itemId, int moxResinCost, int agaResinCost, int lyeResinCost) {
+        this.itemName = itemName;
+        this.itemId = itemId;
+        this.componentCost.put(PotionComponent.MOX, moxResinCost);
+        this.componentCost.put(PotionComponent.AGA, agaResinCost);
+        this.componentCost.put(PotionComponent.LYE, lyeResinCost);
+    }
+
+    public String itemName() {
+        return itemName;
+    }
+
+    public int itemId() {
+        return itemId;
+    }
+
+    public Map<PotionComponent, Integer> componentCost() {
+        return componentCost;
+    }
+
+    public int componentCost(PotionComponent component) {
+        return componentCost.get(component);
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/RewardItem.java
+++ b/src/main/java/work/fking/masteringmixology/RewardItem.java
@@ -2,9 +2,6 @@ package work.fking.masteringmixology;
 
 import net.runelite.api.ItemID;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum RewardItem {
     NONE("None", 0, false, 0, 0, 0),
     APPRENTICE_POTION_PACK("Apprentice Potion Pack", ItemID.APPRENTICE_POTION_PACK, true, 420, 70, 30),

--- a/src/main/java/work/fking/masteringmixology/RewardItem.java
+++ b/src/main/java/work/fking/masteringmixology/RewardItem.java
@@ -5,10 +5,8 @@ import net.runelite.api.ItemID;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("unused") // The items are used in the config
 public enum RewardItem {
     NONE("None", 0, 0, 0, 0),
-
     APPRENTICE_POTION_PACK("Apprentice Potion Pack", ItemID.APPRENTICE_POTION_PACK, 420, 70, 30),
     ADEPT_POTION_PACK("Adept Potion Pack", ItemID.ADEPT_POTION_PACK, 180, 440, 70),
     EXPERT_POTION_PACK("Expert Potion Pack", ItemID.EXPERT_POTION_PACK, 410, 320, 480),
@@ -40,10 +38,6 @@ public enum RewardItem {
 
     public int itemId() {
         return itemId;
-    }
-
-    public Map<PotionComponent, Integer> componentCost() {
-        return componentCost;
     }
 
     public int componentCost(PotionComponent component) {


### PR DESCRIPTION
This change adds new infoboxes to track progress towards a goal and adds a config section for picking this and changing some settings.
~~This is based on top of #15 which needs to be merged first, idk how github will handle that but we'll see!~~

### Changes
- **Goal Tracking Infobox:** Displays the overall percentage towards the selected reward goal, with individual component progress visible on hover.
- **Resin Tracking Infoboxes:** Shows individual resin type progress towards the goal. Configurable to show either the percentage completed or the remaining amount needed, capped at 100% and 0% as applicable.
- Adds a new method for checking if the player is in the lab region which includes the area just outside the actual lab
- Reward Tracking Config section:
  - **Selected Reward:** Allows users to select a reward to track resin progress towards.
  - **Goal Tracking Infobox:** Toggles the infobox displaying progress towards the selected reward.
  - **Resin Infoboxes:** Enables tracking infoboxes for each resin type.
  - **Resin Infobox Display Type:** Configures the resin infoboxes to display either the percentage completed or the amount left for each resin type.

### Images
The goal tracker
![image](https://github.com/user-attachments/assets/162fd48f-623f-4cb8-8618-1f5410c97d95)
The config
![image](https://github.com/user-attachments/assets/2e88c6c3-4697-4965-aab2-bf43643b3886)
Resin trackers showing how much left till goal
![image](https://github.com/user-attachments/assets/cac47abd-0202-4802-b8c4-81268f4df872)
Resin trackers showing percentage completed
![image](https://github.com/user-attachments/assets/f2fa710f-1632-438d-a3ef-3a8c744e3455)

Let me know if anything needs changing :)