### PR TITLE
Added shortest path sorting option

### DIFF
--- a/src/main/java/work/fking/masteringmixology/PotionComparators.java
+++ b/src/main/java/work/fking/masteringmixology/PotionComparators.java
@@ -1,0 +1,24 @@
+package work.fking.masteringmixology;
+
+import java.util.Comparator;
+
+public class PotionComparators {
+    public static Comparator<PotionOrder> byStation() {
+        return Comparator.comparing(order -> order.potionModifier().ordinal());
+    }
+
+    public static Comparator<PotionOrder> shortestPath() {
+        return Comparator.comparing(order -> {
+            switch (order.potionModifier()) {
+                case CRYSTALISED:
+                    return 1;
+                case CONCENTRATED:
+                    return 2;
+                case HOMOGENOUS:
+                    return 3;
+                default:
+                    throw new IllegalStateException("Unexpected value: " + order.potionModifier().toString());
+            }
+        });
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -4,8 +4,19 @@ import java.util.Comparator;
 
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
-    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal()));
-
+    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal())),
+    SHORTEST_PATH("Shortest Path", Comparator.comparing(order -> {
+        switch (order.potionModifier()) {
+            case CRYSTALISED:
+                return 1;
+            case CONCENTRATED:
+                return 2;
+            case HOMOGENOUS:
+                return 3;
+            default:
+                throw new IllegalStateException("Unexpected value: " + order.potionModifier().toString());
+        }
+    }));
     private final String name;
     private final Comparator<PotionOrder> comparator;
 

--- a/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrderSorting.java
@@ -4,19 +4,8 @@ import java.util.Comparator;
 
 public enum PotionOrderSorting {
     VANILLA("Vanilla (random)", null),
-    BY_STATION("By station", Comparator.comparing(order -> order.potionModifier().ordinal())),
-    SHORTEST_PATH("Shortest Path", Comparator.comparing(order -> {
-        switch (order.potionModifier()) {
-            case CRYSTALISED:
-                return 1;
-            case CONCENTRATED:
-                return 2;
-            case HOMOGENOUS:
-                return 3;
-            default:
-                throw new IllegalStateException("Unexpected value: " + order.potionModifier().toString());
-        }
-    }));
+    BY_STATION("By station", PotionComparators.byStation()),
+    SHORTEST_PATH("Shortest Path", PotionComparators.shortestPath());
     private final String name;
     private final Comparator<PotionOrder> comparator;
 


### PR DESCRIPTION
Adds a sorting option that should result in optimal movement.
Crystallizer -> Concentrator -> Homogenizer


Pathing previews:

All stations
![image](https://github.com/user-attachments/assets/f28cd36c-692d-4124-8c3a-f059c400fff0)

Concentrator -> Homogenizer
![image](https://github.com/user-attachments/assets/96865562-3281-469b-8a86-248e06d11344)

Crystallizer -> Concentrator
![image](https://github.com/user-attachments/assets/c55f9dc7-0917-4f5a-98ac-7a5c2f656c2d)


Crystallizer -> Homogenizer
![image](https://github.com/user-attachments/assets/329760a4-9922-47bb-9129-e19db0ad2e48)
