### PR TITLE
Add configurable highlight styles

### DIFF
--- a/src/main/java/work/fking/masteringmixology/HighlightStyle.java
+++ b/src/main/java/work/fking/masteringmixology/HighlightStyle.java
@@ -1,0 +1,6 @@
+package work.fking.masteringmixology;
+
+public enum HighlightStyle {
+    OUTLINE,
+    CLICK_BOX
+}

--- a/src/main/java/work/fking/masteringmixology/HighlightedObject.java
+++ b/src/main/java/work/fking/masteringmixology/HighlightedObject.java
@@ -1,0 +1,43 @@
+package work.fking.masteringmixology;
+
+import net.runelite.api.TileObject;
+
+import java.awt.Color;
+
+public class HighlightedObject {
+
+    private final TileObject object;
+    private final Color color;
+    private final HighlightReason reason;
+
+    public HighlightedObject(TileObject object, Color color, HighlightReason reason) {
+        this.object = object;
+        this.color = color;
+        this.reason = reason;
+    }
+
+    public TileObject object() {
+        return object;
+    }
+
+    public Color color() {
+        return color;
+    }
+
+    public HighlightReason reason() {
+        return reason;
+    }
+
+    public enum HighlightReason {
+        STATION,
+        QUICK_ACTION,
+        LEVER,
+        DIGWEED
+    }
+
+    public enum HighlightStyle {
+        OUTLINE,
+        CLICK_BOX,
+        HULL,
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/HighlightedObject.java
+++ b/src/main/java/work/fking/masteringmixology/HighlightedObject.java
@@ -37,7 +37,6 @@ public class HighlightedObject {
 
     public enum HighlightStyle {
         OUTLINE,
-        CLICK_BOX,
-        HULL,
+        CLICK_BOX
     }
 }

--- a/src/main/java/work/fking/masteringmixology/HighlightedObject.java
+++ b/src/main/java/work/fking/masteringmixology/HighlightedObject.java
@@ -8,12 +8,10 @@ public class HighlightedObject {
 
     private final TileObject object;
     private final Color color;
-    private final HighlightReason reason;
 
-    public HighlightedObject(TileObject object, Color color, HighlightReason reason) {
+    public HighlightedObject(TileObject object, Color color) {
         this.object = object;
         this.color = color;
-        this.reason = reason;
     }
 
     public TileObject object() {
@@ -22,21 +20,5 @@ public class HighlightedObject {
 
     public Color color() {
         return color;
-    }
-
-    public HighlightReason reason() {
-        return reason;
-    }
-
-    public enum HighlightReason {
-        STATION,
-        QUICK_ACTION,
-        LEVER,
-        DIGWEED
-    }
-
-    public enum HighlightStyle {
-        OUTLINE,
-        CLICK_BOX
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -46,6 +46,17 @@ public interface MasteringMixologyConfig extends Config {
         return false;
     }
 
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "notifyDigweed",
+            name = "Notify DigWeed",
+            description = "Toggles digweed notifications on or off",
+            position = 4
+    )
+    default Notification notifyDigWeed() {
+        return Notification.ON;
+    }
+
 
     // Highlights Section
     @ConfigSection(
@@ -101,13 +112,13 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = HIGHLIGHTS,
-            keyName = "notifyDigweed",
-            name = "Notify DigWeed",
-            description = "Toggles digweed notifications on or off",
+            keyName = "highlightStyle",
+            name = "Highlight Style",
+            description = "Change the style of the highlights",
             position = 5
     )
-    default Notification notifyDigWeed() {
-        return Notification.ON;
+    default HighlightStyle highlightStyle() {
+        return HighlightStyle.OUTLINE;
     }
 
     @ConfigItem(
@@ -145,43 +156,10 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = HIGHLIGHTS,
-            keyName = "highlightStyle",
-            name = "Highlight Style",
-            description = "Change the style of the highlight",
-            position = 9
-    )
-    default HighlightedObject.HighlightStyle highlightStyle() {
-        return HighlightedObject.HighlightStyle.OUTLINE;
-    }
-
-    @ConfigItem(
-            section = HIGHLIGHTS,
-            keyName = "stationQuickActionHighlightStyle",
-            name = "Quick-action Style",
-            description = "Configures the station quick-action highlight style",
-            position = 10
-    )
-    default HighlightedObject.HighlightStyle stationQuickActionHighlightStyle() {
-        return HighlightedObject.HighlightStyle.CLICK_BOX;
-    }
-
-    @ConfigItem(
-            section = HIGHLIGHTS,
-            keyName = "leverHighlightStyle",
-            name = "Lever Style",
-            description = "Configures the lever highlight style",
-            position = 12
-    )
-    default HighlightedObject.HighlightStyle leverHighlightStyle() {
-        return HighlightedObject.HighlightStyle.OUTLINE;
-    }
-
-    @ConfigItem(
-            section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",
             description = "Configures the border width of the object highlights",
-            position = 13
+            position = 9
     )
     default int highlightBorderWidth() {
         return 2;
@@ -192,7 +170,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightFeather",
             name = "Feather",
             description = "Configures the amount of 'feathering' to be applied to the object highlights",
-            position = 14
+            position = 10
     )
     default int highlightFeather() {
         return 1;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -15,13 +15,7 @@ public interface MasteringMixologyConfig extends Config {
 
     String CONFIG_GROUP = "masteringmixology";
 
-    @ConfigSection(
-            name = "Highlights",
-            description = "Highlighting related configuration",
-            position = 10
-    )
-    String HIGHLIGHTS = "Highlights";
-
+    // General Configurations
     @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
@@ -30,46 +24,6 @@ public interface MasteringMixologyConfig extends Config {
     )
     default PotionOrderSorting potionOrderSorting() {
         return PotionOrderSorting.VANILLA;
-    }
-
-    @ConfigItem(
-            keyName = "highlightLevers",
-            name = "Highlight levers",
-            description = "Highlight levers",
-            position = 2
-    )
-    default boolean highlightLevers() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "highlightStations",
-            name = "Highlight stations",
-            description = "Toggles alchemical station highlighting on or off",
-            position = 2
-    )
-    default boolean highlightStations() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "highlightQuickActionEvents",
-            name = "Highlight quick-action events",
-            description = "Toggles station quick-action events highlighting on or off",
-            position = 2
-    )
-    default boolean highlightQuickActionEvents() {
-        return true;
-    }
-
-    @ConfigItem(
-            keyName = "identifyPotions",
-            name = "Identify potions",
-            description = "Identify potions in your inventory",
-            position = 2
-    )
-    default boolean identifyPotions() {
-        return true;
     }
 
     @ConfigItem(
@@ -83,26 +37,70 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "stationHighlightColor",
-            name = "Station color",
-            description = "Configures the default station highlight color",
+            keyName = "identifyPotions",
+            name = "Identify potions",
+            description = "Identify potions in your inventory",
             position = 3
     )
-    default Color stationHighlightColor() {
-        return Color.MAGENTA;
+    default boolean identifyPotions() {
+        return true;
+    }
+
+
+    // Highlights Section
+    @ConfigSection(
+            name = "Highlights",
+            description = "Highlighting related configuration",
+            position = 10
+    )
+    String HIGHLIGHTS = "Highlights";
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "highlightLevers",
+            name = "Highlight levers",
+            description = "Highlight levers",
+            position = 1
+    )
+    default boolean highlightLevers() {
+        return true;
     }
 
     @ConfigItem(
-            keyName = "stationQuickActionHighlightColor",
-            name = "Quick-action color",
-            description = "Configures the station quick-action highlight color",
+            section = HIGHLIGHTS,
+            keyName = "highlightStations",
+            name = "Highlight stations",
+            description = "Toggles alchemical station highlighting on or off",
+            position = 2
+    )
+    default boolean highlightStations() {
+        return true;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "highlightQuickActionEvents",
+            name = "Highlight quick-action events",
+            description = "Toggles station quick-action events highlighting on or off",
+            position = 3
+    )
+    default boolean highlightQuickActionEvents() {
+        return true;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "highlightDigweed",
+            name = "Highlight DigWeed",
+            description = "Toggles digweed highlighting on or off",
             position = 4
     )
-    default Color stationQuickActionHighlightColor() {
-        return Color.GREEN;
+    default boolean highlightDigWeed() {
+        return true;
     }
 
     @ConfigItem(
+            section = HIGHLIGHTS,
             keyName = "notifyDigweed",
             name = "Notify DigWeed",
             description = "Toggles digweed notifications on or off",
@@ -113,20 +111,33 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "highlightDigweed",
-            name = "Highlight DigWeed",
-            description = "Toggles digweed highlighting on or off",
+            section = HIGHLIGHTS,
+            keyName = "stationHighlightColor",
+            name = "Station color",
+            description = "Configures the default station highlight color",
             position = 6
     )
-    default boolean highlightDigWeed() {
-        return true;
+    default Color stationHighlightColor() {
+        return Color.MAGENTA;
     }
 
     @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "stationQuickActionHighlightColor",
+            name = "Quick-action color",
+            description = "Configures the station quick-action highlight color",
+            position = 7
+    )
+    default Color stationQuickActionHighlightColor() {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
             keyName = "digweedHighlightColor",
             name = "DigWeed color",
             description = "Configures the digweed highlight color",
-            position = 7
+            position = 8
     )
     default Color digweedHighlightColor() {
         return Color.GREEN;
@@ -134,9 +145,54 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = HIGHLIGHTS,
+            keyName = "highlightStyle",
+            name = "Highlight Style",
+            description = "Change the style of the highlight",
+            position = 9
+    )
+    default HighlightedObject.HighlightStyle highlightStyle() {
+        return HighlightedObject.HighlightStyle.OUTLINE;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "stationQuickActionHighlightStyle",
+            name = "Quick-action Style",
+            description = "Configures the station quick-action highlight style",
+            position = 10
+    )
+    default HighlightedObject.HighlightStyle stationQuickActionHighlightStyle() {
+        return HighlightedObject.HighlightStyle.CLICK_BOX;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "digweedHighlightStyle",
+            name = "DigWeed Style",
+            description = "Configures the DigWeed highlight style",
+            position = 11
+    )
+    default HighlightedObject.HighlightStyle digweedHighlightStyle() {
+        return HighlightedObject.HighlightStyle.OUTLINE;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
+            keyName = "leverHighlightStyle",
+            name = "Lever Style",
+            description = "Configures the lever highlight style",
+            position = 12
+    )
+    default HighlightedObject.HighlightStyle leverHighlightStyle() {
+        return HighlightedObject.HighlightStyle.OUTLINE;
+    }
+
+    @ConfigItem(
+            section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",
-            description = "Configures the border width of the object highlights"
+            description = "Configures the border width of the object highlights",
+            position = 13
     )
     default int highlightBorderWidth() {
         return 2;
@@ -146,7 +202,8 @@ public interface MasteringMixologyConfig extends Config {
             section = HIGHLIGHTS,
             keyName = "highlightFeather",
             name = "Feather",
-            description = "Configures the amount of 'feathering' to be applied to the object highlights"
+            description = "Configures the amount of 'feathering' to be applied to the object highlights",
+            position = 14
     )
     default int highlightFeather() {
         return 1;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -36,9 +36,7 @@ public class MasteringMixologyOverlay extends Overlay {
             TileObject object = highlightedObject.object();
             Color color = highlightedObject.color();
 
-            // Determine the highlight style to use
-            HighlightedObject.HighlightStyle highlightStyle = getHighlightStyle(highlightedObject.reason());
-            switch (highlightStyle) {
+            switch (config.highlightStyle()) {
                 case OUTLINE:
                     modelOutlineRenderer.drawOutline(object, config.highlightBorderWidth(), color, config.highlightFeather());
                     break;
@@ -48,19 +46,6 @@ public class MasteringMixologyOverlay extends Overlay {
             }
         }
         return null;
-    }
-
-    private HighlightedObject.HighlightStyle getHighlightStyle(HighlightedObject.HighlightReason reason) {
-        switch (reason) {
-            case QUICK_ACTION:
-                return config.stationQuickActionHighlightStyle();
-            case LEVER:
-                return config.leverHighlightStyle();
-            case STATION:
-            case DIGWEED:
-            default:
-                return config.highlightStyle();
-        }
     }
 
     private void drawShape(Graphics2D graphics, Shape shape, Color color) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -1,7 +1,5 @@
 package work.fking.masteringmixology;
 
-import net.runelite.api.DecorativeObject;
-import net.runelite.api.GameObject;
 import net.runelite.api.TileObject;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -46,13 +44,6 @@ public class MasteringMixologyOverlay extends Overlay {
                     break;
                 case CLICK_BOX:
                     drawShape(graphics, object.getClickbox(), color);
-                    break;
-                case HULL:
-                    if (object instanceof GameObject) {
-                        drawShape(graphics, ((GameObject) object).getConvexHull(), color);
-                    } else if (object instanceof DecorativeObject) {
-                        drawShape(graphics, ((DecorativeObject) object).getConvexHull(), color);
-                    }
                     break;
             }
         }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -1,22 +1,32 @@
 package work.fking.masteringmixology;
 
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.GameObject;
+import net.runelite.api.TileObject;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
+import net.runelite.client.util.ColorUtil;
 
 import javax.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.Stroke;
 
 public class MasteringMixologyOverlay extends Overlay {
-
     private final MasteringMixologyPlugin plugin;
+    private final MasteringMixologyConfig config;
     private final ModelOutlineRenderer modelOutlineRenderer;
 
     @Inject
-    MasteringMixologyOverlay(MasteringMixologyPlugin plugin, ModelOutlineRenderer modelOutlineRenderer) {
+    MasteringMixologyOverlay(MasteringMixologyPlugin plugin, MasteringMixologyConfig config, ModelOutlineRenderer modelOutlineRenderer) {
         this.plugin = plugin;
+        this.config = config;
         this.modelOutlineRenderer = modelOutlineRenderer;
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
@@ -25,8 +35,50 @@ public class MasteringMixologyOverlay extends Overlay {
     @Override
     public Dimension render(Graphics2D graphics) {
         for (var highlightedObject : plugin.highlightedObjects().values()) {
-            modelOutlineRenderer.drawOutline(highlightedObject.object(), highlightedObject.outlineWidth(), highlightedObject.color(), highlightedObject.feather());
+            TileObject object = highlightedObject.object();
+            Color color = highlightedObject.color();
+
+            // Determine the highlight style to use
+            HighlightedObject.HighlightStyle highlightStyle = getHighlightStyle(highlightedObject.reason());
+            switch (highlightStyle) {
+                case OUTLINE:
+                    modelOutlineRenderer.drawOutline(object, config.highlightBorderWidth(), color, config.highlightFeather());
+                    break;
+                case CLICK_BOX:
+                    drawShape(graphics, object.getClickbox(), color);
+                    break;
+                case HULL:
+                    if (object instanceof GameObject) {
+                        drawShape(graphics, ((GameObject) object).getConvexHull(), color);
+                    } else if (object instanceof DecorativeObject) {
+                        drawShape(graphics, ((DecorativeObject) object).getConvexHull(), color);
+                    }
+                    break;
+            }
         }
         return null;
+    }
+
+    private HighlightedObject.HighlightStyle getHighlightStyle(HighlightedObject.HighlightReason reason) {
+        switch (reason) {
+            case STATION:
+                return config.highlightStyle();
+            case QUICK_ACTION:
+                return config.stationQuickActionHighlightStyle();
+            case LEVER:
+                return config.leverHighlightStyle();
+            case DIGWEED:
+                return config.digweedHighlightStyle();
+            default:
+                return HighlightedObject.HighlightStyle.OUTLINE;
+        }
+    }
+
+    private void drawShape(Graphics2D graphics, Shape shape, Color color) {
+        if (shape != null) {
+            Stroke stroke = new BasicStroke((float) config.highlightBorderWidth());
+            Color fillColor = ColorUtil.colorWithAlpha(color, 20);
+            OverlayUtil.renderPolygon(graphics, shape, color.darker(), fillColor, stroke);
+        }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -5,7 +5,6 @@ import net.runelite.api.Client;
 import net.runelite.api.FontID;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
-import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GraphicsObjectCreated;
@@ -225,7 +224,7 @@ public class MasteringMixologyPlugin extends Plugin {
             for (var order : potionOrders) {
                 if (order.potionType() == potionType && !order.fulfilled()) {
                     unHighlightAllStations();
-                    highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
+                    highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
                     return;
                 }
             }
@@ -284,7 +283,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_NORTH_EAST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor());
+                    highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned north east.");
             } else {
@@ -293,7 +292,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_EAST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor());
+                    highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned south east.");
             } else {
@@ -302,7 +301,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_WEST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor());
+                    highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned south west.");
             } else {
@@ -311,7 +310,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_NORTH_WEST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor());
+                    highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned north west.");
             } else {
@@ -359,14 +358,14 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
         if (spotAnimId == SPOT_ANIM_ALEMBIC && alembicPotionType != null) {
-            highlightObject(AlchemyObject.ALEMBIC, config.stationQuickActionHighlightColor());
+            highlightObject(AlchemyObject.ALEMBIC, config.stationQuickActionHighlightColor(), HighlightedObject.HighlightReason.QUICK_ACTION);
             // start counting ticks for alembic so we know to un-highlight on the next alembic varbit update
             // note this quick action has a 1 tick window, so we use an int that goes 0 -> 1 -> unhighlight
             alembicQuickActionTicks = 1;
         }
 
         if (spotAnimId == SPOT_ANIM_AGITATOR && agitatorPotionType != null) {
-            highlightObject(AlchemyObject.AGITATOR, config.stationQuickActionHighlightColor());
+            highlightObject(AlchemyObject.AGITATOR, config.stationQuickActionHighlightColor(), HighlightedObject.HighlightReason.QUICK_ACTION);
             // start counting ticks for agitator so we know to un-highlight on the next agitator varbit update
             // note this quick action has a 2-tick window, so we use an int that goes 0 -> 1 -> 2 -> unhighlight
             agitatorQuickActionTicks = 1;
@@ -457,7 +456,7 @@ public class MasteringMixologyPlugin extends Plugin {
         tryHighlightNextStation();
     }
 
-    public void highlightObject(AlchemyObject alchemyObject, Color color) {
+    public void highlightObject(AlchemyObject alchemyObject, Color color, HighlightedObject.HighlightReason reason) {
         var worldView = client.getTopLevelWorldView();
 
         if (worldView == null) {
@@ -477,7 +476,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
 
             if (gameObject.getId() == alchemyObject.objectId()) {
-                highlightedObjects.put(alchemyObject, new HighlightedObject(gameObject, color, config.highlightBorderWidth(), config.highlightFeather()));
+                highlightedObjects.put(alchemyObject, new HighlightedObject(gameObject, color, reason));
                 return;
             }
         }
@@ -485,13 +484,13 @@ public class MasteringMixologyPlugin extends Plugin {
         var decorativeObject = tile.getDecorativeObject();
 
         if (decorativeObject != null && decorativeObject.getId() == alchemyObject.objectId()) {
-            highlightedObjects.put(alchemyObject, new HighlightedObject(decorativeObject, color, config.highlightBorderWidth(), config.highlightFeather()));
+            highlightedObjects.put(alchemyObject, new HighlightedObject(decorativeObject, color, reason));
         }
     }
 
     public void resetDefaultHighlight(AlchemyObject alchemyObject) {
         if (config.highlightStations()) {
-            highlightObject(alchemyObject, config.stationHighlightColor());
+            highlightObject(alchemyObject, config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
         }
     }
 
@@ -510,9 +509,9 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
-        highlightObject(LYE_LEVER, Color.decode("#" + LYE.color()));
-        highlightObject(AGA_LEVER, Color.decode("#" + AGA.color()));
-        highlightObject(MOX_LEVER, Color.decode("#" + MOX.color()));
+        highlightObject(LYE_LEVER, Color.decode("#" + LYE.color()), HighlightedObject.HighlightReason.LEVER);
+        highlightObject(AGA_LEVER, Color.decode("#" + AGA.color()), HighlightedObject.HighlightReason.LEVER);
+        highlightObject(MOX_LEVER, Color.decode("#" + MOX.color()), HighlightedObject.HighlightReason.LEVER);
     }
 
     private void unHighlightLevers() {
@@ -584,7 +583,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             if (inventory.contains(order.potionType().itemId())) {
                 LOGGER.debug("Highlighting station for order {}", order);
-                highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
+                highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
                 break;
             }
         }
@@ -626,37 +625,6 @@ public class MasteringMixologyPlugin extends Plugin {
             return PotionModifier.from(client.getVarbitValue(VARBIT_POTION_MODIFIER_3) - 1);
         } else {
             return null;
-        }
-    }
-
-    public static class HighlightedObject {
-
-        private final TileObject object;
-        private final Color color;
-        private final int outlineWidth;
-        private final int feather;
-
-        private HighlightedObject(TileObject object, Color color, int outlineWidth, int feather) {
-            this.object = object;
-            this.color = color;
-            this.outlineWidth = outlineWidth;
-            this.feather = feather;
-        }
-
-        public TileObject object() {
-            return object;
-        }
-
-        public Color color() {
-            return color;
-        }
-
-        public int outlineWidth() {
-            return outlineWidth;
-        }
-
-        public int feather() {
-            return feather;
         }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -224,7 +224,7 @@ public class MasteringMixologyPlugin extends Plugin {
             for (var order : potionOrders) {
                 if (order.potionType() == potionType && !order.fulfilled()) {
                     unHighlightAllStations();
-                    highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
+                    highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
                     return;
                 }
             }
@@ -283,7 +283,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_NORTH_EAST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
+                    highlightObject(AlchemyObject.DIGWEED_NORTH_EAST, config.digweedHighlightColor());
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned north east.");
             } else {
@@ -292,7 +292,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_EAST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
+                    highlightObject(AlchemyObject.DIGWEED_SOUTH_EAST, config.digweedHighlightColor());
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned south east.");
             } else {
@@ -301,7 +301,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_SOUTH_WEST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
+                    highlightObject(AlchemyObject.DIGWEED_SOUTH_WEST, config.digweedHighlightColor());
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned south west.");
             } else {
@@ -310,7 +310,7 @@ public class MasteringMixologyPlugin extends Plugin {
         } else if (varbitId == VARBIT_DIGWEED_NORTH_WEST) {
             if (value == 1) {
                 if (config.highlightDigWeed()) {
-                    highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor(), HighlightedObject.HighlightReason.DIGWEED);
+                    highlightObject(AlchemyObject.DIGWEED_NORTH_WEST, config.digweedHighlightColor());
                 }
                 notifier.notify(config.notifyDigWeed(), "A digweed has spawned north west.");
             } else {
@@ -358,14 +358,14 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
         if (spotAnimId == SPOT_ANIM_ALEMBIC && alembicPotionType != null) {
-            highlightObject(AlchemyObject.ALEMBIC, config.stationQuickActionHighlightColor(), HighlightedObject.HighlightReason.QUICK_ACTION);
+            highlightObject(AlchemyObject.ALEMBIC, config.stationQuickActionHighlightColor());
             // start counting ticks for alembic so we know to un-highlight on the next alembic varbit update
             // note this quick action has a 1 tick window, so we use an int that goes 0 -> 1 -> unhighlight
             alembicQuickActionTicks = 1;
         }
 
         if (spotAnimId == SPOT_ANIM_AGITATOR && agitatorPotionType != null) {
-            highlightObject(AlchemyObject.AGITATOR, config.stationQuickActionHighlightColor(), HighlightedObject.HighlightReason.QUICK_ACTION);
+            highlightObject(AlchemyObject.AGITATOR, config.stationQuickActionHighlightColor());
             // start counting ticks for agitator so we know to un-highlight on the next agitator varbit update
             // note this quick action has a 2-tick window, so we use an int that goes 0 -> 1 -> 2 -> unhighlight
             agitatorQuickActionTicks = 1;
@@ -456,7 +456,7 @@ public class MasteringMixologyPlugin extends Plugin {
         tryHighlightNextStation();
     }
 
-    public void highlightObject(AlchemyObject alchemyObject, Color color, HighlightedObject.HighlightReason reason) {
+    public void highlightObject(AlchemyObject alchemyObject, Color color) {
         var worldView = client.getTopLevelWorldView();
 
         if (worldView == null) {
@@ -476,7 +476,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
 
             if (gameObject.getId() == alchemyObject.objectId()) {
-                highlightedObjects.put(alchemyObject, new HighlightedObject(gameObject, color, reason));
+                highlightedObjects.put(alchemyObject, new HighlightedObject(gameObject, color));
                 return;
             }
         }
@@ -484,13 +484,13 @@ public class MasteringMixologyPlugin extends Plugin {
         var decorativeObject = tile.getDecorativeObject();
 
         if (decorativeObject != null && decorativeObject.getId() == alchemyObject.objectId()) {
-            highlightedObjects.put(alchemyObject, new HighlightedObject(decorativeObject, color, reason));
+            highlightedObjects.put(alchemyObject, new HighlightedObject(decorativeObject, color));
         }
     }
 
     public void resetDefaultHighlight(AlchemyObject alchemyObject) {
         if (config.highlightStations()) {
-            highlightObject(alchemyObject, config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
+            highlightObject(alchemyObject, config.stationHighlightColor());
         }
     }
 
@@ -509,9 +509,9 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
-        highlightObject(LYE_LEVER, Color.decode("#" + LYE.color()), HighlightedObject.HighlightReason.LEVER);
-        highlightObject(AGA_LEVER, Color.decode("#" + AGA.color()), HighlightedObject.HighlightReason.LEVER);
-        highlightObject(MOX_LEVER, Color.decode("#" + MOX.color()), HighlightedObject.HighlightReason.LEVER);
+        highlightObject(LYE_LEVER, Color.decode("#" + LYE.color()));
+        highlightObject(AGA_LEVER, Color.decode("#" + AGA.color()));
+        highlightObject(MOX_LEVER, Color.decode("#" + MOX.color()));
     }
 
     private void unHighlightLevers() {
@@ -583,7 +583,7 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             if (inventory.contains(order.potionType().itemId())) {
                 LOGGER.debug("Highlighting station for order {}", order);
-                highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor(), HighlightedObject.HighlightReason.STATION);
+                highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
                 break;
             }
         }


### PR DESCRIPTION
This change makes it possible to change the highlight style between the current outline or the object's clickbox

### Changes
- Moved HighlightedObject to it's own class
  - Removed the border and feather from the constructor as we can get these later from the config
  - Added a highlight style field to know what style we should use
- Added support in MasteringMixologyOverlay to draw either style depending on config

Outline
![image](https://github.com/user-attachments/assets/3edb5d6f-b9d2-480e-b164-9f764a6f3b44)
Click box
![image](https://github.com/user-attachments/assets/2ab7168e-0f47-4f49-bb3c-ffeb817d7ff5)

I also reordered the config a bit
![image](https://github.com/user-attachments/assets/0ab8d02e-3673-488d-9e10-05d5f99d6351)


Lmk if anything needs changing :) 