### PR TITLE
Fix config changes not being applied till next action

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -191,6 +192,17 @@ public class MasteringMixologyPlugin extends Plugin {
                 unHighlightAllStations();
             } else {
                 clientThread.invokeLater(this::tryHighlightNextStation);
+            }
+        }
+
+        if (event.getKey().equals("displayResin")) {
+            var baseWidget = client.getWidget(COMPONENT_POTION_ORDERS);
+            if (baseWidget != null) {
+                if (!config.displayResin()) {
+                    clientThread.invokeLater(() -> removeResinText(baseWidget));
+                } else {
+                    clientThread.invokeLater(() -> appendResins(baseWidget));
+                }
             }
         }
 
@@ -432,6 +444,26 @@ public class MasteringMixologyPlugin extends Plugin {
                 orderGraphic.revalidate();
                 orderText.revalidate();
             }
+        }
+    }
+
+    private void removeResinText(Widget widget) {
+        Widget[] children = widget.getChildren();
+        if (children == null || children.length < 3) {
+            return;
+        }
+
+        // Get the balance of all resins
+        String moxResinAmount = String.valueOf(client.getVarpValue(VARP_MOX_RESIN));
+        String agaResinAmount = String.valueOf(client.getVarpValue(VARP_AGA_RESIN));
+        String lyeResinAmount = String.valueOf(client.getVarpValue(VARP_LYE_RESIN));
+
+        // Check if the last three children have texts matching the resin amounts and remove them
+        if (children[children.length - 1].getText().equals(lyeResinAmount) &&
+                children[children.length - 2].getText().equals(agaResinAmount) &&
+                children[children.length - 3].getText().equals(moxResinAmount)) {
+            widget.setChildren(Arrays.copyOf(children, children.length - 3));
+            widget.revalidate();
         }
     }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,8 +186,12 @@ public class MasteringMixologyPlugin extends Plugin {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 
-        if (!config.highlightStations()) {
-            unHighlightAllStations();
+        if (event.getKey().equals("highlightStations")) {
+            if (!config.highlightStations()) {
+                unHighlightAllStations();
+            } else {
+                clientThread.invokeLater(this::tryHighlightNextStation);
+            }
         }
 
         if (!config.highlightDigWeed()) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -249,7 +249,6 @@ public class MasteringMixologyPlugin extends Plugin {
         // Whenever a potion is delivered, all the potion order related varbits are reset to 0 first then
         // set to the new values. We can use this to clear all the stations.
         if (varbitId == VARBIT_POTION_ORDER_1) {
-            System.out.println("Got varbit change with value " + value);
             if (value == 0) {
                 unHighlightAllStations();
             } else {


### PR DESCRIPTION
Turning station highlights off and on wouldn't show the station till you made a new potion

Toggling the display of resin amount wouldn't either update till you delivered an order
this was fixed by checking the last 3 child widgets on the order widget were equal to the resin and removing them.
I was thinking of checking the children length and capping it at 16 but that might break if something is added to it

Lmk if there's a better solution!