### PR TITLE
Add highlights to mixing vessel

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -46,7 +46,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightStations",
             name = "Highlight stations",
             description = "Toggles alchemical station highlighting on or off",
-            position = 2
+            position = 3
     )
     default boolean highlightStations() {
         return true;
@@ -56,9 +56,30 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightQuickActionEvents",
             name = "Highlight quick-action events",
             description = "Toggles station quick-action events highlighting on or off",
-            position = 2
+            position = 4
     )
     default boolean highlightQuickActionEvents() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "highlightMixingVessel",
+            name = "Highlight mixing vessel",
+            description = "Highlight the mixing vessel",
+            position = 5
+    )
+    default boolean highlightMixingVessel() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "highlightMixingVesselInvalid",
+            name = "Highlight invalid mixing vessel",
+            description = "Highlight the mixing vessel red when you have the wrong ingredients",
+            position = 6
+    )
+    // used to enable highlighting the vessel red when you have the wrong ingredients
+    default boolean highlightMixingVesselInvalid() {
         return true;
     }
 
@@ -66,7 +87,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "identifyPotions",
             name = "Identify potions",
             description = "Identify potions in your inventory",
-            position = 2
+            position = 7
     )
     default boolean identifyPotions() {
         return true;
@@ -76,7 +97,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "displayResin",
             name = "Display resin amount",
             description = "Display total resin amounts",
-            position = 2
+            position = 8
     )
     default boolean displayResin() {
         return false;
@@ -86,7 +107,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "stationHighlightColor",
             name = "Station color",
             description = "Configures the default station highlight color",
-            position = 3
+            position = 9
     )
     default Color stationHighlightColor() {
         return Color.MAGENTA;
@@ -96,7 +117,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "stationQuickActionHighlightColor",
             name = "Quick-action color",
             description = "Configures the station quick-action highlight color",
-            position = 4
+            position = 10
     )
     default Color stationQuickActionHighlightColor() {
         return Color.GREEN;
@@ -106,7 +127,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "notifyDigweed",
             name = "Notify DigWeed",
             description = "Toggles digweed notifications on or off",
-            position = 5
+            position = 11
     )
     default Notification notifyDigWeed() {
         return Notification.ON;
@@ -116,7 +137,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "highlightDigweed",
             name = "Highlight DigWeed",
             description = "Toggles digweed highlighting on or off",
-            position = 6
+            position = 12
     )
     default boolean highlightDigWeed() {
         return true;
@@ -126,7 +147,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "digweedHighlightColor",
             name = "DigWeed color",
             description = "Configures the digweed highlight color",
-            position = 7
+            position = 13
     )
     default Color digweedHighlightColor() {
         return Color.GREEN;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -79,7 +79,7 @@ public interface MasteringMixologyConfig extends Config {
             position = 5
     )
     default boolean highlightMixingVessel() {
-        return true;
+        return false;
     }
 
     @ConfigItem(
@@ -103,26 +103,6 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "stationHighlightColor",
-            name = "Station color",
-            description = "Configures the default station highlight color",
-            position = 9
-    )
-    default Color stationHighlightColor() {
-        return Color.MAGENTA;
-    }
-
-    @ConfigItem(
-            keyName = "stationQuickActionHighlightColor",
-            name = "Quick-action color",
-            description = "Configures the station quick-action highlight color",
-            position = 10
-    )
-    default Color stationQuickActionHighlightColor() {
-        return Color.GREEN;
-    }
-
-    @ConfigItem(
             keyName = "notifyDigweed",
             name = "Notify DigWeed",
             description = "Toggles digweed notifications on or off",
@@ -143,16 +123,6 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "digweedHighlightColor",
-            name = "DigWeed color",
-            description = "Configures the digweed highlight color",
-            position = 13
-    )
-    default Color digweedHighlightColor() {
-        return Color.GREEN;
-    }
-
-    @ConfigItem(
             section = HIGHLIGHTS,
             keyName = "highlightBorderWidth",
             name = "Border width",
@@ -170,5 +140,70 @@ public interface MasteringMixologyConfig extends Config {
     )
     default int highlightFeather() {
         return 1;
+    }
+
+
+    // Accessibility section
+    @ConfigSection(
+            name = "Accessibility",
+            description = "Accessibility settings",
+            position = 20,
+            closedByDefault = true
+    )
+    String ACCESSIBILITY = "Accessibility";
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "stationHighlightColor",
+            name = "Station color",
+            description = "Configures the default station highlight color",
+            position = 1
+    )
+    default Color stationHighlightColor() {
+        return Color.MAGENTA;
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "stationQuickActionHighlightColor",
+            name = "Quick-action color",
+            description = "Configures the station quick-action highlight color",
+            position = 2
+    )
+    default Color stationQuickActionHighlightColor() {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "digweedHighlightColor",
+            name = "DigWeed color",
+            description = "Configures the digweed highlight color",
+            position = 3
+    )
+    default Color digweedHighlightColor() {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "vesselHighlightColor",
+            name = "Vessel color",
+            description = "Configures the vessel highlight color",
+            position = 4
+    )
+    default Color vesselHighlightColor() {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "vesselInvalidHighlightColor",
+            name = "Invalid vessel color",
+            description = "Configures the invalid vessel highlight color",
+            position = 5
+    )
+    default Color vesselInvalidHighlightColor() {
+        return Color.RED;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -1,21 +1,30 @@
 package work.fking.masteringmixology;
 
+import net.runelite.api.Client;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 
 import javax.inject.Inject;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.Graphics2D;
 
 public class MasteringMixologyOverlay extends Overlay {
 
+    private final Client client;
     private final MasteringMixologyPlugin plugin;
     private final ModelOutlineRenderer modelOutlineRenderer;
 
     @Inject
-    MasteringMixologyOverlay(MasteringMixologyPlugin plugin, ModelOutlineRenderer modelOutlineRenderer) {
+    MasteringMixologyOverlay(Client client, MasteringMixologyPlugin plugin, ModelOutlineRenderer modelOutlineRenderer) {
+        this.client = client;
         this.plugin = plugin;
         this.modelOutlineRenderer = modelOutlineRenderer;
         setPosition(OverlayPosition.DYNAMIC);
@@ -26,7 +35,35 @@ public class MasteringMixologyOverlay extends Overlay {
     public Dimension render(Graphics2D graphics) {
         for (var highlightedObject : plugin.highlightedObjects().values()) {
             modelOutlineRenderer.drawOutline(highlightedObject.object(), highlightedObject.outlineWidth(), highlightedObject.color(), highlightedObject.feather());
+            drawText(graphics, highlightedObject);
         }
         return null;
+    }
+
+    private void drawText(Graphics2D graphics, MasteringMixologyPlugin.HighlightedObject highlightedObject) {
+        String text = highlightedObject.text();
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+
+        // Increase the font size
+        Font font = FontManager.getRunescapeFont().deriveFont(20f);
+        Font originalFont = graphics.getFont();
+        graphics.setFont(font);
+
+        // Draw the text
+        LocalPoint textLocation = highlightedObject.object().getLocalLocation();
+        // Parse </br> in the text and split it into multiple lines
+        int zOffset = 100;
+        for (String line : text.split("</br>")) {
+            Point canvasLocation = Perspective.getCanvasTextLocation(client, graphics, textLocation, line, zOffset);
+            OverlayUtil.renderTextLocation(graphics, canvasLocation, line, highlightedObject.color());
+
+            // Decrease the zOffset with font height + 5 to draw the next line below the previous one
+            zOffset -= graphics.getFontMetrics().getHeight() + 5;
+        }
+
+        // Set the font back to the original
+        graphics.setFont(originalFont);
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyOverlay.java
@@ -1,30 +1,21 @@
 package work.fking.masteringmixology;
 
-import net.runelite.api.Client;
-import net.runelite.api.Perspective;
-import net.runelite.api.Point;
-import net.runelite.api.coords.LocalPoint;
-import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 
 import javax.inject.Inject;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.Graphics2D;
 
 public class MasteringMixologyOverlay extends Overlay {
 
-    private final Client client;
     private final MasteringMixologyPlugin plugin;
     private final ModelOutlineRenderer modelOutlineRenderer;
 
     @Inject
-    MasteringMixologyOverlay(Client client, MasteringMixologyPlugin plugin, ModelOutlineRenderer modelOutlineRenderer) {
-        this.client = client;
+    MasteringMixologyOverlay(MasteringMixologyPlugin plugin, ModelOutlineRenderer modelOutlineRenderer) {
         this.plugin = plugin;
         this.modelOutlineRenderer = modelOutlineRenderer;
         setPosition(OverlayPosition.DYNAMIC);
@@ -35,35 +26,7 @@ public class MasteringMixologyOverlay extends Overlay {
     public Dimension render(Graphics2D graphics) {
         for (var highlightedObject : plugin.highlightedObjects().values()) {
             modelOutlineRenderer.drawOutline(highlightedObject.object(), highlightedObject.outlineWidth(), highlightedObject.color(), highlightedObject.feather());
-            drawText(graphics, highlightedObject);
         }
         return null;
-    }
-
-    private void drawText(Graphics2D graphics, MasteringMixologyPlugin.HighlightedObject highlightedObject) {
-        String text = highlightedObject.text();
-        if (text == null || text.isEmpty()) {
-            return;
-        }
-
-        // Increase the font size
-        Font font = FontManager.getRunescapeFont().deriveFont(20f);
-        Font originalFont = graphics.getFont();
-        graphics.setFont(font);
-
-        // Draw the text
-        LocalPoint textLocation = highlightedObject.object().getLocalLocation();
-        // Parse </br> in the text and split it into multiple lines
-        int zOffset = 100;
-        for (String line : text.split("</br>")) {
-            Point canvasLocation = Perspective.getCanvasTextLocation(client, graphics, textLocation, line, zOffset);
-            OverlayUtil.renderTextLocation(graphics, canvasLocation, line, highlightedObject.color());
-
-            // Decrease the zOffset with font height + 5 to draw the next line below the previous one
-            zOffset -= graphics.getFontMetrics().getHeight() + 5;
-        }
-
-        // Set the font back to the original
-        graphics.setFont(originalFont);
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,6 +186,10 @@ public class MasteringMixologyPlugin extends Plugin {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 
+        if (!config.highlightStations()) {
+            unHighlightAllStations();
+        }
+
         // Refresh the highlight on the vessel if the config changes
         if (event.getKey().equals("highlightMixingVessel") || event.getKey().equals("highlightMixingVesselInvalid")) {
             clientThread.invokeLater(() -> validateVesselPotion(client.getVarbitValue(VARBIT_MIXING_VESSEL_POTION)));


### PR DESCRIPTION
This adds two new config options to highlight the mixing vessel when a valid potion is ready for pickup or when you've made an invalid recipe

![image](https://github.com/user-attachments/assets/723cf9da-481e-472a-9e4f-987b1c2a5675)
![image](https://github.com/user-attachments/assets/e0ed6df7-f515-47dd-88f8-b4555a82ce7a)
![image](https://github.com/user-attachments/assets/d54f9eb2-cd4c-406f-a9e1-3293a39fd6aa)
![image](https://github.com/user-attachments/assets/2a7fd448-5543-4951-8380-6d4043f8d2a6)


Lmk if something needs changing, otherwise feel free to review & merge :)