### PR TITLE
Fix issue with orders above the player's level by correcting indexes.

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -399,16 +399,19 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
+        int indexOffset = 0;
         for (int i = 0; i < potionOrders.size(); i++) {
             var order = potionOrders.get(i);
 
-            var orderGraphic = children[order.idx() * 2 + 1];
-            var orderText = children[order.idx() * 2 + 2];
+            var orderGraphic = children[order.idx() * 2 + 1 + indexOffset];
+            var orderText = children[order.idx() * 2 + 2 + indexOffset];
 
             // If anyone still has orders they don't have the herblore level to deliver there's an extra RECTANGLE component which
             // causes the idx calculations to select the wrong components
             if (orderGraphic.getType() != WidgetType.GRAPHIC || orderText.getType() != WidgetType.TEXT) {
-                continue;
+                indexOffset++;
+                orderGraphic = children[order.idx() * 2 + 1 + indexOffset];
+                orderText = children[order.idx() * 2 + 2 + indexOffset];
             }
             var builder = new StringBuilder(orderText.getText());
 


### PR DESCRIPTION
Fixes the UI element selections when an order above the player's level is present.
This can occur if the player boosts their herblore level.

Before
![image](https://github.com/user-attachments/assets/8f77096c-47d1-4c8f-8fb1-baac9672ce33)


After
![image](https://github.com/user-attachments/assets/be78f0b5-9278-4d2f-917f-ee6a833f26f4)
