### PR TITLE
Improve potion highlighting

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -93,6 +93,16 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "allowMultipleStationHighlights",
+            name = "Allow Multiple Station Highlights",
+            description = "If multiple recipes have the same potion type, multiple stations will be highlighted instead of just the top.",
+            position = 3
+    )
+    default boolean allowMultipleStationHighlights() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "stationQuickActionHighlightColor",
             name = "Quick-action color",
             description = "Configures the station quick-action highlight color",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -560,17 +560,19 @@ public class MasteringMixologyPlugin extends Plugin {
         unHighlightAllStations();
 
         for (var item : inventory.getItems()) {
-            var potion = PotionType.fromItemId(item.getId());
-            if (potion != null) {
-                for (var order : potionOrders) {
-                    if (!order.fulfilled() && potion == order.potionType()) {
-                        LOGGER.debug("Highlighting station for order {}", order);
-                        highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
-                    }
-                }
-
-                return;
+            var potionType = PotionType.fromItemId(item.getId());
+            if (potionType == null || potionType.modifiedItemId() == item.getId()) {
+                continue;
             }
+
+            for (var order : potionOrders) {
+                if (!order.fulfilled() && potionType == order.potionType()) {
+                    LOGGER.debug("Highlighting station for order {}", order);
+                    highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
+                }
+            }
+
+            return;
         }
     }
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -559,21 +559,17 @@ public class MasteringMixologyPlugin extends Plugin {
 
         unHighlightAllStations();
 
-        for (var order : potionOrders) {
-            if (order.fulfilled()) {
-                continue;
-            }
-
-            for (var item : inventory.getItems()) {
-                var potion = PotionType.fromItemId(item.getId());
-                if (potion != null) {
-                    if (potion == order.potionType()) {
+        for (var item : inventory.getItems()) {
+            var potion = PotionType.fromItemId(item.getId());
+            if (potion != null) {
+                for (var order : potionOrders) {
+                    if (!order.fulfilled() && potion == order.potionType()) {
                         LOGGER.debug("Highlighting station for order {}", order);
                         highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
                     }
-
-                    break;
                 }
+
+                return;
             }
         }
     }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -186,7 +186,9 @@ public class MasteringMixologyPlugin extends Plugin {
             clientThread.invokeLater(this::updatePotionOrders);
         }
 
-        if (!config.highlightStations()) {
+        if (config.highlightStations()) {
+            clientThread.invokeLater(this::tryHighlightNextStation);
+        } else {
             unHighlightAllStations();
         }
 
@@ -206,7 +208,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event) {
-        if (!inLab || !config.highlightStations() || event.getContainerId() != InventoryID.INVENTORY.getId()) {
+        if (!inLab || event.getContainerId() != InventoryID.INVENTORY.getId()) {
             return;
         }
         // Do not update the highlight if there's a potion in a station
@@ -553,7 +555,7 @@ public class MasteringMixologyPlugin extends Plugin {
     private void tryHighlightNextStation() {
         var inventory = client.getItemContainer(InventoryID.INVENTORY);
 
-        if (inventory == null) {
+        if (!config.highlightStations() || inventory == null) {
             return;
         }
 
@@ -569,6 +571,9 @@ public class MasteringMixologyPlugin extends Plugin {
                 if (!order.fulfilled() && potionType == order.potionType()) {
                     LOGGER.debug("Highlighting station for order {}", order);
                     highlightObject(order.potionModifier().alchemyObject(), config.stationHighlightColor());
+                    if (!config.allowMultipleStationHighlights()) {
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
- Fixes bug where station is highlighted even if not the top potion
- Supports highlighting multiple stations if they have the same potion
  - Seems like an improvement in all cases to me but I can put this behind a config flag if yall are worried about changing current behaviour too much
- Simplifies code by removing duplicate logic and removing redundant calls to tryHighlightNextStation

# Bugged behaviour

https://github.com/user-attachments/assets/ad66e950-9464-43fc-9699-290fd95f6d79

# Proposed new behaviour

https://github.com/user-attachments/assets/917bfa5d-fc01-494a-bbbc-3cac91a278c4

