### PR TITLE
Added unfinished potion tracking feature

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -73,6 +73,16 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "unfinishedTracking",
+            name = "Unfinished Potion Tracking",
+            description = "Toggles tracking of unfinished potions in your inventory to highlight corresponding potion orders.",
+            position = 2
+    )
+    default boolean unfinishedTracking() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "displayResin",
             name = "Display resin amount",
             description = "Display total resin amounts",
@@ -151,4 +161,5 @@ public interface MasteringMixologyConfig extends Config {
     default int highlightFeather() {
         return 1;
     }
+
 }

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -6,6 +6,7 @@ public class PotionOrder {
     private final PotionType potionType;
     private final PotionModifier potionModifier;
 
+    private boolean unfinishedAvailable;
     private boolean fulfilled;
 
     public PotionOrder(int idx, PotionType potionType, PotionModifier potionModifier) {
@@ -29,9 +30,14 @@ public class PotionOrder {
     public void setFulfilled(boolean fulfilled) {
         this.fulfilled = fulfilled;
     }
-
+    public void setUnfinishedAvailable(boolean unfinishedAvailable) {
+        this.unfinishedAvailable = unfinishedAvailable;
+    }
     public boolean fulfilled() {
         return fulfilled;
+    }
+    public boolean isUnfinishedAvailable() {
+        return unfinishedAvailable;
     }
 
     @Override


### PR DESCRIPTION
This is my first RuneLite PR, so please feel free to provide feedback if something needs tweaking!

This PR adds a new config option to enable tracking of unfinished potions in the inventory. It updates potion orders with an "unfinished available" state when an unfinished potion matches an order.

Changes include:

- Initializing unfinished potion tracking on startup by simulating an ItemContainerChanged event.
- Ensuring only one matching order is updated per inventory item to handle duplicates properly.
- Refactoring event handling to improve clarity and maintainability.

Ready for review & merge!