### PR TITLE
Track prepared potions

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -1,11 +1,7 @@
 package work.fking.masteringmixology;
 
 import com.google.inject.Provides;
-import net.runelite.api.Client;
-import net.runelite.api.FontID;
-import net.runelite.api.GameState;
-import net.runelite.api.InventoryID;
-import net.runelite.api.TileObject;
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GraphicsObjectCreated;
@@ -32,11 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static work.fking.masteringmixology.AlchemyObject.AGA_LEVER;
 import static work.fking.masteringmixology.AlchemyObject.LYE_LEVER;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -1,6 +1,7 @@
 package work.fking.masteringmixology;
 
-import com.google.inject.Provides;import net.runelite.api.Client;
+import com.google.inject.Provides;
+import net.runelite.api.Client;
 import net.runelite.api.FontID;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -1,7 +1,11 @@
 package work.fking.masteringmixology;
 
-import com.google.inject.Provides;
-import net.runelite.api.*;
+import com.google.inject.Provides;import net.runelite.api.Client;
+import net.runelite.api.FontID;
+import net.runelite.api.GameState;
+import net.runelite.api.InventoryID;
+import net.runelite.api.TileObject;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GraphicsObjectCreated;
@@ -28,7 +32,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.awt.Color;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedList;
 
 import static work.fking.masteringmixology.AlchemyObject.AGA_LEVER;
 import static work.fking.masteringmixology.AlchemyObject.LYE_LEVER;

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -426,6 +426,8 @@ public class MasteringMixologyPlugin extends Plugin {
 
             if (order.fulfilled()) {
                 builder.append(" (<col=00ff00>done!</col>)");
+            } else if(order.prepared()){
+                builder.append(" (<col=ffff00>").append(order.potionType().abbreviation()).append("</col>)");
             } else {
                 builder.append(" (").append(order.potionType().recipe()).append(")");
             }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -293,6 +293,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 unHighlightAllStations();
             } else {
                 clientThread.invokeAtTickEnd(this::updatePotionOrders);
+                clientThread.invokeAtTickEnd(this::triggerItemContainerChanged);
             }
         } else if (varbitId == VARBIT_ALEMBIC_POTION) {
             if (value == 0) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -499,6 +499,7 @@ public class MasteringMixologyPlugin extends Plugin {
         updatePotionOrders();
         highlightLevers();
         tryHighlightNextStation();
+        triggerItemContainerChanged();
     }
 
     public void highlightObject(AlchemyObject alchemyObject, Color color) {
@@ -586,6 +587,18 @@ public class MasteringMixologyPlugin extends Plugin {
 
         if (varbitType != null) {
             client.queueChangedVarp(varbitType.getIndex());
+        }
+    }
+
+    public void triggerItemContainerChanged() {
+        // Trigger a fake ItemContainer update to force run the inventory check
+        if (client.getItemContainer(InventoryID.INVENTORY) != null) {
+            ItemContainerChanged simulatedEvent = new ItemContainerChanged(
+                    InventoryID.INVENTORY.getId(),
+                    client.getItemContainer(InventoryID.INVENTORY)
+            );
+
+            onItemContainerChanged(simulatedEvent);
         }
     }
 

--- a/src/main/java/work/fking/masteringmixology/PotionOrder.java
+++ b/src/main/java/work/fking/masteringmixology/PotionOrder.java
@@ -7,6 +7,7 @@ public class PotionOrder {
     private final PotionModifier potionModifier;
 
     private boolean fulfilled;
+    private boolean prepared;
 
     public PotionOrder(int idx, PotionType potionType, PotionModifier potionModifier) {
         this.idx = idx;
@@ -32,6 +33,14 @@ public class PotionOrder {
 
     public boolean fulfilled() {
         return fulfilled;
+    }
+
+    public void setPrepared(boolean prepared) {
+        this.prepared = prepared;
+    }
+
+    public boolean prepared() {
+        return prepared;
     }
 
     @Override


### PR DESCRIPTION
This updates how recipes are displayed in the main infobox, such that orders with a prepared / unmodified potion are visually distinct from ones you have yet to create, like how completed/modified potions replace the order with `done!` in green. 

- Adds a new flag on `PotionOrder` to track if the order is prepared
- When the player inventory changes, it checks all unfulfilled orders to see if they have a prepared potion available
- Minorly refactored `onItemContainerChanged` so that prepared order checking can happen on every inventory change, while station highlighting updates can still use highlighting-specific requirements (e.g. highlighting enabled in plugin config, no current potion in progress)
- Retriggers inventory change checks whenever the plugin initializes or the player turns in potions
  - This also means if you have a fully complete potion in your inventory which your new order requests, the plugin properly updates to `done!` for that potion.


Since the default plugin behavior (e.g. swapping the recipe to `done!`) does not have any config options, this change follows suit, and aims to fill my need (visually indicating which potions you've already prepped so you can easily see what to do next) without modifying the behavior in any way that someone would care about changing/reverting.

I also considered swapping the text to say "prepared" or "ready!" but found that marginally more obtrusive compared to still showing the component parts (especially since "prepared" often wraps to the next line of text), and I don't think something like this really warrants config options. 

----

I wrote this before seeing @cytostatika's draft PR #97, and borrowed a function to re-trigger inventory updates on plugin launch such that they work correctly on logout/login with unfinished potions. Not sure on the plugin etiquette regarding making my own PR vs pushing updates to another, but using my existing PR seemed faster/easier than proposing updates to theirs which handle duplicate orders.

----

Ready for review and merge