### PR TITLE
Update station highlighting on turn-in

### DIFF
--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -278,6 +278,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 unHighlightAllStations();
             } else {
                 clientThread.invokeAtTickEnd(this::updatePotionOrders);
+                clientThread.invokeAtTickEnd(this::triggerItemContainerChanged);
             }
         } else if (varbitId == VARBIT_ALEMBIC_POTION) {
             if (value == 0) {
@@ -573,6 +574,18 @@ public class MasteringMixologyPlugin extends Plugin {
         }
 
         triggerPotionOrderUpdate();
+    }
+
+    public void triggerItemContainerChanged() {
+        // Trigger a fake ItemContainer update to force run the inventory check
+        if (client.getItemContainer(InventoryID.INVENTORY) != null) {
+            ItemContainerChanged simulatedEvent = new ItemContainerChanged(
+                    InventoryID.INVENTORY.getId(),
+                    client.getItemContainer(InventoryID.INVENTORY)
+            );
+
+            onItemContainerChanged(simulatedEvent);
+        }
     }
 
     public void triggerPotionOrderUpdate() {


### PR DESCRIPTION
Re-triggers an inventory check for partially-mixed potions when turning in orders, instead of only updating on true inventory updates. This way, station highlights work correctly as soon as you turn in one order and get a new one, which looks less buggy than if they show up later and can help the player spot that they don't need to mix a new MAL, for example.

Fixes the 2nd part of issue #114 (the 1st part is regarding pre-made fully modified potions, which would require complicated manual tracking)

----

Example of the issue:
<img width="1246" height="730" alt="image" src="https://github.com/user-attachments/assets/463e234c-7fdb-4ca5-a86e-20a9bf7b8eec" />
Note that I have an unfinished ALA in my inventory directly after turning in an order set, and one is requested, but no stations are highlighted. As soon as I move the ALA to a different inventory slot, highlighting happens again:
<img width="1246" height="730" alt="image" src="https://github.com/user-attachments/assets/83497b12-77c1-462f-8f37-7ebdb3db9d63" />

With this PR, the station is highlighted immediately on turn-in. 