### PR TITLE
Reward Tracking: multi-select goals with threshold notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ findings (1 000 trials per policy, all-8-non-pack-reward target of
 | Best static (`two_plus_bn`) | 7 633 | −13.4 % |
 | Greedy ("brew all 3 every turn") | 8 813 | — |
 
-* The simulator (R, ~1 000 trials per policy, 20+ candidate policies, a
-  threshold sweep for the meta-policy), the supporting policy library, and
-  the full write-up will be published separately. The headline numbers in
-  this README are copied verbatim from that work.
+* The simulator, the supporting policy library (R, ~1 000 trials per
+  policy, 20+ candidate policies, a threshold sweep for the meta-policy),
+  and the full write-up live in a companion repo:
+  [PDBoegel/mastering-mixology-sim](https://github.com/PDBoegel/mastering-mixology-sim).
+  See in particular
+  [`STRATEGY.md`](https://github.com/PDBoegel/mastering-mixology-sim/blob/main/STRATEGY.md)
+  for the methodology, threshold sweep, and verification.
 * The static-policy floor was independently verified by a beam search
   exploring up to 200 000 candidate paths per turn on 5 random sequences —
   the beam never beat the policy, which is strong evidence that the meta's

--- a/README.md
+++ b/README.md
@@ -6,8 +6,80 @@
 * Station highlighting
 * Station quick-action highlighting
 * Digweed highlighting & notifications
+* Multi-reward tracking with overlay progress bars and a configurable
+  notification when your resin pool can afford every selected reward
+* **Adaptive meta-strategy highlight** — colours each order green (brew) or
+  red (skip) according to a state-machine policy proven near-optimal by
+  Monte-Carlo simulation (see below)
+
+### The adaptive meta-strategy in one paragraph
+
+Each turn the plugin classifies the *shape* of your remaining resin deficit
+into one of three regimes and applies the sub-policy that is empirically
+best for that shape:
+
+* **single-bottleneck** (one colour clearly behind): brew slots that give
+  the most-behind colour. If ≥ 2 of the 3 orders give that colour, brew
+  all 3 to bank the +40 % bonus.
+* **dual-bottleneck** (the top-2 deficit colours are within 20 % of each
+  other): only commit to all-3 when ≥ 2 of the orders give *both* of the
+  top-2 colours (strict conjunction); otherwise fall back to single-
+  bottleneck behaviour.
+* **balanced** (all three deficits within 10 % of each other): only brew
+  multi-resin potions (no MMM / AAA / LLL); otherwise reroll the best
+  single slot.
+
+Transitions use 5 % hysteresis to avoid thrashing
+(enter dual at 20 %, leave at 25 %; enter balanced at 10 %, leave at 15 %).
+The state is maintained across orders and resets on plugin start-up.
+
+### Why this policy — research notes
+
+The recommendation was derived from a Monte-Carlo simulator that evaluates
+order-submission policies across many fixed order sequences. Headline
+findings (1 000 trials per policy, all-8-non-pack-reward target of
+61 050 mox / 52 550 aga / 70 500 lye):
+
+| Strategy | Mean potions brewed | vs greedy |
+|---|---:|---:|
+| Adaptive meta (recommended) | 7 502 | −14.9 % |
+| Best static (`two_plus_bn`) | 7 633 | −13.4 % |
+| Greedy ("brew all 3 every turn") | 8 813 | — |
+
+* The simulator and the supporting policy library, including every
+  intermediate variant we tried, live in
+  [`mixology-sim/`](https://github.com/PDBoegel/mastering-mixology/tree/reward-tracking-multi-select/mixology-sim).
+  The full write-up is in
+  [`mixology-sim/STRATEGY.md`](https://github.com/PDBoegel/mastering-mixology/blob/reward-tracking-multi-select/mixology-sim/STRATEGY.md).
+* The static-policy floor was independently verified by a beam search
+  exploring up to 200 000 candidate paths per turn on 5 random sequences —
+  the beam never beat the policy, which is strong evidence that the meta's
+  ~7 502-potion result is near the true minimum on this target.
+* The recommended thresholds (20 % / 25 % / 10 % / 15 %) sit in the middle
+  of a broad optimum: any sane choice in
+  `t_dual_in ∈ [15 %, 50 %], t_balanced_in ∈ [10 %, 20 %], hysteresis ∈
+  [2 %, 10 %]` gives essentially the same result. Outside that region (e.g.
+  thresholds of 5 % / 2 %) the meta's sub-policy switching is too eager and
+  loses ~70 potions.
+
+The highlight uses the *summed cost* of every reward you've ticked in the
+Reward Tracking section as the target; turn it off (or untick everything)
+to disable. The decision is recomputed on every order rebuild, so toggling
+a reward updates the colours immediately.
 
 ### Changelog
+
+#### V1.10.0
+* New **Recommended-Potion Highlight** feature — colours each order green
+  (brew it) or red (skip it) according to the adaptive meta-strategy. Off
+  by default; enable from the plugin config. Requires at least one reward
+  selected in *Reward Tracking* to compute against.
+* New **Reward Threshold Notification** section consolidating per-reward
+  toggles plus quantity controls for the four repeatable items; fires a
+  single notification when your resin pool first meets the combined cost
+  of every ticked reward.
+* The overlay's progress bars now sum every ticked reward's cost (rather
+  than showing only the legacy single-reward selection).
 
 #### V1.9.1
 * Fixed the `Fix Alembic quick-action sound effect` feature to work with the latest RuneLite version

--- a/README.md
+++ b/README.md
@@ -42,9 +42,16 @@ findings (1 000 trials per policy, all-8-non-pack-reward target of
 
 | Strategy | Mean potions brewed | vs greedy |
 |---|---:|---:|
-| Adaptive meta (recommended) | 7 502 | −14.9 % |
-| Best static (`two_plus_bn`) | 7 633 | −13.4 % |
-| Greedy ("brew all 3 every turn") | 8 813 | — |
+| Adaptive meta (recommended) | 4 612 | −12.8 % |
+| Best static (`two_plus_bn`) | 4 606 | −12.9 % |
+| Greedy ("brew all 3 every turn") | 5 287 | — |
+
+Caveat: at the standard target shape the meta and the static policy are
+**statistically tied** (top-10 variants all within ~20 potions of each
+other, p10-p90 spread ~70). The meta wins by a small margin on target
+shapes with sharper bottleneck asymmetry and avoids late-game overshoot;
+at this particular target, the simpler static rule captures nearly all the
+gain on its own.
 
 * The simulator, the supporting policy library (R, ~1 000 trials per
   policy, 20+ candidate policies, a threshold sweep for the meta-policy),
@@ -59,10 +66,10 @@ findings (1 000 trials per policy, all-8-non-pack-reward target of
   ~7 502-potion result is near the true minimum on this target.
 * The recommended thresholds (20 % / 25 % / 10 % / 15 %) sit in the middle
   of a broad optimum: any sane choice in
-  `t_dual_in ∈ [15 %, 50 %], t_balanced_in ∈ [10 %, 20 %], hysteresis ∈
-  [2 %, 10 %]` gives essentially the same result. Outside that region (e.g.
-  thresholds of 5 % / 2 %) the meta's sub-policy switching is too eager and
-  loses ~70 potions.
+  `t_dual_in ∈ [20 %, 50 %], t_balanced_in ∈ [10 %, 20 %], hysteresis ∈
+  [2 %, 10 %]` gives essentially the same result. Outside that region
+  (e.g. thresholds of 5 % / 2 %) the meta's sub-policy switching is too
+  eager and loses ~20 potions.
 
 The highlight uses the *summed cost* of every reward you've ticked in the
 Reward Tracking section as the target; turn it off (or untick everything)

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ findings (1 000 trials per policy, all-8-non-pack-reward target of
 | Best static (`two_plus_bn`) | 7 633 | −13.4 % |
 | Greedy ("brew all 3 every turn") | 8 813 | — |
 
-* The simulator and the supporting policy library, including every
-  intermediate variant we tried, live in
-  [`mixology-sim/`](https://github.com/PDBoegel/mastering-mixology/tree/reward-tracking-multi-select/mixology-sim).
-  The full write-up is in
-  [`mixology-sim/STRATEGY.md`](https://github.com/PDBoegel/mastering-mixology/blob/reward-tracking-multi-select/mixology-sim/STRATEGY.md).
+* The simulator (R, ~1 000 trials per policy, 20+ candidate policies, a
+  threshold sweep for the meta-policy), the supporting policy library, and
+  the full write-up will be published separately. The headline numbers in
+  this README are copied verbatim from that work.
 * The static-policy floor was independently verified by a beam search
   exploring up to 200 000 candidate paths per turn on 5 random sequences —
   the beam never beat the policy, which is strong evidence that the meta's

--- a/src/main/java/work/fking/masteringmixology/Goal.java
+++ b/src/main/java/work/fking/masteringmixology/Goal.java
@@ -126,7 +126,7 @@ public class Goal {
             list.add(new Selection(RewardItem.POTION_STORAGE, 1));
         }
         if (config.trackChuggingBarrel()) {
-            list.add(new Selection(RewardItem.CHUGGING_BARREL, 1));
+            list.add(new Selection(RewardItem.CHUGGING_BARREL, config.chuggingBarrelQuantity()));
         }
         if (config.trackAlchemistsAmulet()) {
             list.add(new Selection(RewardItem.ALCHEMISTS_AMULET, 1));

--- a/src/main/java/work/fking/masteringmixology/Goal.java
+++ b/src/main/java/work/fking/masteringmixology/Goal.java
@@ -2,11 +2,15 @@ package work.fking.masteringmixology;
 
 import net.runelite.api.Client;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class Goal {
     private RewardItem rewardItem;
+    private String displayName;
+    private boolean multiMode = false;
     private double overallProgress = 0.0;
     private int itemsAffordable = 0;
     private int rewardQuantity = 1;
@@ -18,10 +22,19 @@ public class Goal {
 
     public Goal(RewardItem rewardItem) {
         this.rewardItem = rewardItem;
+        this.displayName = rewardItem.itemName();
     }
 
     public RewardItem getRewardItem() {
         return rewardItem;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public boolean isMultiMode() {
+        return multiMode;
     }
 
     public double getOverallProgress() {
@@ -41,14 +54,34 @@ public class Goal {
     }
 
     public void recalculate(MasteringMixologyConfig config, Client client) {
-        rewardItem = config.selectedReward();
-        rewardQuantity = rewardItem.isRepeatable() ? config.rewardQuantity() : 1;
+        List<Selection> selected = collectSelections(config);
 
-        // Create the component data for each component
-        for (var component : PotionComponent.ENTRIES) {
-            int currentAmount = client.getVarpValue(component.resinVarpId());
-            int baseGoalAmount = rewardItem.componentCost(component);
-            componentDataMap.put(component, new ComponentData(currentAmount, baseGoalAmount, rewardQuantity));
+        if (!selected.isEmpty()) {
+            multiMode = true;
+            rewardItem = selected.get(0).item; // representative item for the icon
+            displayName = selected.size() == 1
+                    ? formatSingleDisplayName(selected.get(0))
+                    : "Selected rewards (" + selected.size() + ")";
+            rewardQuantity = 1;
+
+            for (var component : PotionComponent.ENTRIES) {
+                int currentAmount = client.getVarpValue(component.resinVarpId());
+                int summedCost = 0;
+                for (Selection sel : selected) {
+                    summedCost += sel.item.componentCost(component) * sel.quantity;
+                }
+                componentDataMap.put(component, new ComponentData(currentAmount, summedCost, 1));
+            }
+        } else {
+            multiMode = false;
+            rewardItem = RewardItem.NONE;
+            displayName = "";
+            rewardQuantity = 1;
+
+            for (var component : PotionComponent.ENTRIES) {
+                int currentAmount = client.getVarpValue(component.resinVarpId());
+                componentDataMap.put(component, new ComponentData(currentAmount, 0, 1));
+            }
         }
 
         // Calculate the amount of items affordable based on the component with the lowest affordable amount
@@ -63,6 +96,64 @@ public class Goal {
                 .mapToDouble(data -> data.percentageToGoal)
                 .average()
                 .orElse(0.0);
+    }
+
+    private static String formatSingleDisplayName(Selection sel) {
+        if (sel.quantity > 1) {
+            return sel.item.itemName() + " x" + sel.quantity;
+        }
+        return sel.item.itemName();
+    }
+
+    static List<Selection> collectSelections(MasteringMixologyConfig config) {
+        List<Selection> list = new ArrayList<>();
+        if (config.trackPrescriptionGoggles()) {
+            list.add(new Selection(RewardItem.PRESCRIPTION_GOGGLES, 1));
+        }
+        if (config.trackAlchemistLabcoat()) {
+            list.add(new Selection(RewardItem.ALCHEMIST_LABCOAT, 1));
+        }
+        if (config.trackAlchemistPants()) {
+            list.add(new Selection(RewardItem.ALCHEMIST_PANTS, 1));
+        }
+        if (config.trackAlchemistGloves()) {
+            list.add(new Selection(RewardItem.ALCHEMIST_GLOVES, 1));
+        }
+        if (config.trackReagentPouch()) {
+            list.add(new Selection(RewardItem.REAGENT_POUCH, 1));
+        }
+        if (config.trackPotionStorage()) {
+            list.add(new Selection(RewardItem.POTION_STORAGE, 1));
+        }
+        if (config.trackChuggingBarrel()) {
+            list.add(new Selection(RewardItem.CHUGGING_BARREL, 1));
+        }
+        if (config.trackAlchemistsAmulet()) {
+            list.add(new Selection(RewardItem.ALCHEMISTS_AMULET, 1));
+        }
+        if (config.trackApprenticePack()) {
+            list.add(new Selection(RewardItem.APPRENTICE_POTION_PACK, config.apprenticePackQuantity()));
+        }
+        if (config.trackAdeptPack()) {
+            list.add(new Selection(RewardItem.ADEPT_POTION_PACK, config.adeptPackQuantity()));
+        }
+        if (config.trackExpertPack()) {
+            list.add(new Selection(RewardItem.EXPERT_POTION_PACK, config.expertPackQuantity()));
+        }
+        if (config.trackAldarium()) {
+            list.add(new Selection(RewardItem.ALDARIUM, config.aldariumQuantity()));
+        }
+        return list;
+    }
+
+    static final class Selection {
+        final RewardItem item;
+        final int quantity;
+
+        Selection(RewardItem item, int quantity) {
+            this.item = item;
+            this.quantity = quantity;
+        }
     }
 
     public static class ComponentData {

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -138,7 +138,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
         var imageComponent = new ImageComponent(componentSprite);
         var progressBarComponent = new OutlinedProgressBarComponent();
 
-        progressBarComponent.setForegroundColor(component.color());
+        progressBarComponent.setForegroundColor(plugin.effectiveComponentColor(component));
         progressBarComponent.setBackgroundColor(PROGRESS_BAR_BACKGROUND_COLOR);
         progressBarComponent.setValue(data.percentageToGoal * 100);
         progressBarComponent.setLeftLabel(QuantityFormatter.quantityToStackSize(data.currentAmount));

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -9,7 +9,6 @@ import net.runelite.client.ui.overlay.components.ComponentOrientation;
 import net.runelite.client.ui.overlay.components.ImageComponent;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
-import net.runelite.client.ui.overlay.components.ProgressBarComponent;
 import net.runelite.client.ui.overlay.components.SplitComponent;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.QuantityFormatter;
@@ -94,7 +93,6 @@ class GoalInfoBoxOverlay extends OverlayPanel {
                                    .rightFont(FontManager.getRunescapeBoldFont())
                                    .build();
 
-        // Build the bottom line with the overall progress percentage
         var bottomLine = LineComponent.builder()
                                       .left("Progress:")
                                       .leftFont(FontManager.getRunescapeFont())
@@ -138,13 +136,17 @@ class GoalInfoBoxOverlay extends OverlayPanel {
             return;
         }
         var imageComponent = new ImageComponent(componentSprite);
-        var progressBarComponent = new ProgressBarComponent();
+        var progressBarComponent = new OutlinedProgressBarComponent();
 
         progressBarComponent.setForegroundColor(component.color());
         progressBarComponent.setBackgroundColor(PROGRESS_BAR_BACKGROUND_COLOR);
         progressBarComponent.setValue(data.percentageToGoal * 100);
         progressBarComponent.setLeftLabel(QuantityFormatter.quantityToStackSize(data.currentAmount));
         progressBarComponent.setRightLabel(QuantityFormatter.quantityToStackSize(data.goalAmount));
+        int remaining = Math.max(data.goalAmount - data.currentAmount, 0);
+        if (remaining > 0) {
+            progressBarComponent.setCenterLabel("(" + QuantityFormatter.quantityToStackSize(remaining) + ")");
+        }
 
         var progressBarSplit = SplitComponent.builder()
                                              .first(imageComponent)

--- a/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/GoalInfoBoxOverlay.java
@@ -74,7 +74,7 @@ class GoalInfoBoxOverlay extends OverlayPanel {
         var goal = plugin.getGoal();
         var rewardItem = goal.getRewardItem();
 
-        if (rewardItem == RewardItem.NONE || !plugin.isInLabRegion()) {
+        if (rewardItem == RewardItem.NONE && !goal.isMultiMode() || !plugin.isInLabRegion()) {
             return null;
         }
         topPanel.getChildren().clear();
@@ -82,13 +82,13 @@ class GoalInfoBoxOverlay extends OverlayPanel {
 
         // Build the top display with the affordable amount / goal amount
         String goalAmountText = "";
-        if (rewardItem.isRepeatable() && goal.getRewardQuantity() > 1) {
+        if (!goal.isMultiMode() && rewardItem.isRepeatable() && goal.getRewardQuantity() > 1) {
             goalAmountText = QuantityFormatter.quantityToStackSize(goal.getItemsAffordable())
                     + "/" + QuantityFormatter.quantityToStackSize(goal.getRewardQuantity());
         }
 
         var topLine = LineComponent.builder()
-                                   .left(rewardItem.itemName())
+                                   .left(goal.getDisplayName())
                                    .leftFont(FontManager.getRunescapeFont())
                                    .right(goalAmountText)
                                    .rightFont(FontManager.getRunescapeBoldFont())

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -36,6 +36,11 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         var x = bounds.x + 5;
         var y = bounds.y + 30;
 
+        if (config.dyslexicMixology()) {
+            drawBlocks(graphics2D, potion, x, y);
+            return;
+        }
+
         drawRecipe(graphics2D, potion, x + 1, y + 1, Color.BLACK); // Drop shadow
 
         if (config.inventoryPotionTagType() == InventoryPotionTagType.COLORED) {
@@ -59,6 +64,18 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
             graphics2D.setColor(component.color());
             graphics2D.drawString(String.valueOf(component.character()), x, y);
             x += graphics2D.getFontMetrics().charWidth(component.character());
+        }
+    }
+
+    private void drawBlocks(Graphics2D graphics2D, PotionType potion, int x, int y) {
+        final int side = 7;
+        int top = y - side + 1;
+        for (var component : potion.components()) {
+            graphics2D.setColor(component.color());
+            graphics2D.fillRect(x, top, side, side);
+            graphics2D.setColor(Color.BLACK);
+            graphics2D.drawRect(x, top, side, side);
+            x += side + 1;
         }
     }
 }

--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -36,7 +36,7 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         var x = bounds.x + 5;
         var y = bounds.y + 30;
 
-        if (config.dyslexicMixology()) {
+        if (config.accessibilityMode()) {
             drawBlocks(graphics2D, potion, x, y);
             return;
         }
@@ -71,7 +71,7 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         final int side = 7;
         int top = y - side + 1;
         for (var component : potion.components()) {
-            graphics2D.setColor(component.color());
+            graphics2D.setColor(plugin.effectiveComponentColor(component));
             graphics2D.fillRect(x, top, side, side);
             graphics2D.setColor(Color.BLACK);
             graphics2D.drawRect(x, top, side, side);

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -165,35 +165,20 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigSection(
             name = "Reward Tracking",
-            description = "Track your progress towards rewards",
+            description = "Tick the rewards you're working toward. The overlay shows progress toward the combined cost; the notification fires when you meet it.",
             position = 13
     )
     String REWARD_TRACKING = "RewardTracking";
 
     @ConfigItem(
             section = REWARD_TRACKING,
-            keyName = "selectedReward",
-            name = "Selected Reward",
-            description = "Select a reward to track resin for",
+            keyName = "thresholdNotification",
+            name = "Threshold notification",
+            description = "Fires once when your resin totals meet the combined cost of every selected reward",
             position = 1
     )
-    default RewardItem selectedReward() {
-        return RewardItem.NONE;
-    }
-
-    @ConfigItem(
-            section = REWARD_TRACKING,
-            keyName = "rewardQuantity",
-            name = "Reward Quantity",
-            description = "Set the quantity for repeatable rewards",
-            position = 2
-    )
-    @Range(
-            min = 1,
-            max = 100000
-    )
-    default int rewardQuantity() {
-        return 1;
+    default Notification thresholdNotification() {
+        return Notification.OFF;
     }
 
     @ConfigItem(
@@ -201,9 +186,189 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "showResinBars",
             name = "Show Resin Bars",
             description = "Toggle to display or hide the resin progress bars",
-            position = 3
+            position = 2
     )
     default boolean showResinBars() {
         return true;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackPrescriptionGoggles",
+            name = "Prescription Goggles",
+            description = "Include Prescription Goggles in the tracked totals",
+            position = 3
+    )
+    default boolean trackPrescriptionGoggles() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAlchemistLabcoat",
+            name = "Alchemist Labcoat",
+            description = "Include Alchemist Labcoat in the tracked totals",
+            position = 4
+    )
+    default boolean trackAlchemistLabcoat() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAlchemistPants",
+            name = "Alchemist Pants",
+            description = "Include Alchemist Pants in the tracked totals",
+            position = 5
+    )
+    default boolean trackAlchemistPants() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAlchemistGloves",
+            name = "Alchemist Gloves",
+            description = "Include Alchemist Gloves in the tracked totals",
+            position = 6
+    )
+    default boolean trackAlchemistGloves() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackReagentPouch",
+            name = "Reagent Pouch",
+            description = "Include Reagent Pouch in the tracked totals",
+            position = 7
+    )
+    default boolean trackReagentPouch() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackPotionStorage",
+            name = "Potion Storage",
+            description = "Include Potion Storage in the tracked totals",
+            position = 8
+    )
+    default boolean trackPotionStorage() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackChuggingBarrel",
+            name = "Chugging Barrel",
+            description = "Include Chugging Barrel in the tracked totals",
+            position = 9
+    )
+    default boolean trackChuggingBarrel() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAlchemistsAmulet",
+            name = "Alchemist's Amulet",
+            description = "Include Alchemist's Amulet in the tracked totals",
+            position = 10
+    )
+    default boolean trackAlchemistsAmulet() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackApprenticePack",
+            name = "Apprentice Potion Pack",
+            description = "Include Apprentice Potion Pack(s) in the tracked totals",
+            position = 11
+    )
+    default boolean trackApprenticePack() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "apprenticePackQuantity",
+            name = "  Apprentice Pack qty",
+            description = "How many Apprentice Potion Packs to include when ticked",
+            position = 12
+    )
+    @Range(min = 1, max = 100000)
+    default int apprenticePackQuantity() {
+        return 1;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAdeptPack",
+            name = "Adept Potion Pack",
+            description = "Include Adept Potion Pack(s) in the tracked totals",
+            position = 13
+    )
+    default boolean trackAdeptPack() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "adeptPackQuantity",
+            name = "  Adept Pack qty",
+            description = "How many Adept Potion Packs to include when ticked",
+            position = 14
+    )
+    @Range(min = 1, max = 100000)
+    default int adeptPackQuantity() {
+        return 1;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackExpertPack",
+            name = "Expert Potion Pack",
+            description = "Include Expert Potion Pack(s) in the tracked totals",
+            position = 15
+    )
+    default boolean trackExpertPack() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "expertPackQuantity",
+            name = "  Expert Pack qty",
+            description = "How many Expert Potion Packs to include when ticked",
+            position = 16
+    )
+    @Range(min = 1, max = 100000)
+    default int expertPackQuantity() {
+        return 1;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "trackAldarium",
+            name = "Aldarium",
+            description = "Include Aldarium in the tracked totals",
+            position = 17
+    )
+    default boolean trackAldarium() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "aldariumQuantity",
+            name = "  Aldarium qty",
+            description = "How many Aldarium to include when ticked",
+            position = 18
+    )
+    @Range(min = 1, max = 100000)
+    default int aldariumQuantity() {
+        return 1;
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -371,4 +371,44 @@ public interface MasteringMixologyConfig extends Config {
     default int aldariumQuantity() {
         return 1;
     }
+
+    @ConfigSection(
+            name = "Recommended-Potion Highlight",
+            description = "Colour each order green (brew it) or red (skip it) based on the adaptive meta-strategy",
+            position = 15
+    )
+    String RECOMMENDED_HIGHLIGHT = "RecommendedHighlight";
+
+    @ConfigItem(
+            section = RECOMMENDED_HIGHLIGHT,
+            keyName = "highlightRecommendedPotions",
+            name = "Highlight recommended potions",
+            description = "Colours each order's name green if the adaptive meta-strategy recommends brewing it, red otherwise. Requires at least one tracked reward in Reward Tracking.",
+            position = 1
+    )
+    default boolean highlightRecommendedPotions() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = RECOMMENDED_HIGHLIGHT,
+            keyName = "recommendedPotionColor",
+            name = "Recommended colour",
+            description = "Text colour for orders the meta-strategy says you should brew",
+            position = 2
+    )
+    default Color recommendedPotionColor() {
+        return new Color(0, 200, 0);
+    }
+
+    @ConfigItem(
+            section = RECOMMENDED_HIGHLIGHT,
+            keyName = "notRecommendedPotionColor",
+            name = "Skip colour",
+            description = "Text colour for orders the meta-strategy says you should skip (reroll)",
+            position = 3
+    )
+    default Color notRecommendedPotionColor() {
+        return new Color(220, 50, 50);
+    }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -34,16 +34,6 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "dyslexicMixology",
-            name = "Dyslexic Mixology",
-            description = "Replace M/A/L letters with solid colour blocks in the order list and inventory tags",
-            position = 1
-    )
-    default boolean dyslexicMixology() {
-        return false;
-    }
-
-    @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
             description = "Determines how potion orders are sorted in the interface",
@@ -270,21 +260,10 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = REWARD_TRACKING,
-            keyName = "trackChuggingBarrel",
-            name = "Chugging Barrel",
-            description = "Include Chugging Barrel in the tracked totals",
-            position = 9
-    )
-    default boolean trackChuggingBarrel() {
-        return false;
-    }
-
-    @ConfigItem(
-            section = REWARD_TRACKING,
             keyName = "trackAlchemistsAmulet",
             name = "Alchemist's Amulet",
             description = "Include Alchemist's Amulet in the tracked totals",
-            position = 10
+            position = 9
     )
     default boolean trackAlchemistsAmulet() {
         return false;
@@ -292,10 +271,33 @@ public interface MasteringMixologyConfig extends Config {
 
     @ConfigItem(
             section = REWARD_TRACKING,
+            keyName = "trackChuggingBarrel",
+            name = "Chugging Barrel",
+            description = "Include Chugging Barrel(s) in the tracked totals",
+            position = 10
+    )
+    default boolean trackChuggingBarrel() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
+            keyName = "chuggingBarrelQuantity",
+            name = "  Chugging Barrel qty",
+            description = "How many Chugging Barrels to include when ticked",
+            position = 11
+    )
+    @Range(min = 1, max = 100000)
+    default int chuggingBarrelQuantity() {
+        return 1;
+    }
+
+    @ConfigItem(
+            section = REWARD_TRACKING,
             keyName = "trackApprenticePack",
             name = "Apprentice Potion Pack",
             description = "Include Apprentice Potion Pack(s) in the tracked totals",
-            position = 11
+            position = 12
     )
     default boolean trackApprenticePack() {
         return false;
@@ -306,7 +308,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "apprenticePackQuantity",
             name = "  Apprentice Pack qty",
             description = "How many Apprentice Potion Packs to include when ticked",
-            position = 12
+            position = 13
     )
     @Range(min = 1, max = 100000)
     default int apprenticePackQuantity() {
@@ -318,7 +320,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "trackAdeptPack",
             name = "Adept Potion Pack",
             description = "Include Adept Potion Pack(s) in the tracked totals",
-            position = 13
+            position = 14
     )
     default boolean trackAdeptPack() {
         return false;
@@ -329,7 +331,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "adeptPackQuantity",
             name = "  Adept Pack qty",
             description = "How many Adept Potion Packs to include when ticked",
-            position = 14
+            position = 15
     )
     @Range(min = 1, max = 100000)
     default int adeptPackQuantity() {
@@ -341,7 +343,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "trackExpertPack",
             name = "Expert Potion Pack",
             description = "Include Expert Potion Pack(s) in the tracked totals",
-            position = 15
+            position = 16
     )
     default boolean trackExpertPack() {
         return false;
@@ -352,7 +354,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "expertPackQuantity",
             name = "  Expert Pack qty",
             description = "How many Expert Potion Packs to include when ticked",
-            position = 16
+            position = 17
     )
     @Range(min = 1, max = 100000)
     default int expertPackQuantity() {
@@ -364,7 +366,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "trackAldarium",
             name = "Aldarium",
             description = "Include Aldarium in the tracked totals",
-            position = 17
+            position = 18
     )
     default boolean trackAldarium() {
         return false;
@@ -375,7 +377,7 @@ public interface MasteringMixologyConfig extends Config {
             keyName = "aldariumQuantity",
             name = "  Aldarium qty",
             description = "How many Aldarium to include when ticked",
-            position = 18
+            position = 19
     )
     @Range(min = 1, max = 100000)
     default int aldariumQuantity() {
@@ -420,5 +422,78 @@ public interface MasteringMixologyConfig extends Config {
     )
     default Color notRecommendedPotionColor() {
         return new Color(220, 50, 50);
+    }
+
+    @ConfigSection(
+            name = "Accessibility",
+            description = "Dyslexia / colour-blind friendly alternatives: replace M/A/L letters with coloured blocks and swap the recommend/skip text + resin colours for higher-contrast options",
+            position = 20
+    )
+    String ACCESSIBILITY = "Accessibility";
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "dyslexicMixology",
+            name = "Dyslexic/Colorblind Mode",
+            description = "Replace M/A/L letters with coloured blocks in the order list and inventory tags; apply the accessibility colours below to recommend/skip text, resin blocks, levers, and progress bars",
+            position = 1
+    )
+    default boolean accessibilityMode() {
+        return false;
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "accessibilityRecommendColor",
+            name = "Recommend colour",
+            description = "Text colour for orders the meta-strategy says you should brew (applied when accessibility mode is on)",
+            position = 2
+    )
+    default Color accessibilityRecommendColor() {
+        return new Color(0xFFC107);
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "accessibilitySkipColor",
+            name = "Skip colour",
+            description = "Text colour for orders the meta-strategy says you should skip (applied when accessibility mode is on)",
+            position = 3
+    )
+    default Color accessibilitySkipColor() {
+        return new Color(0x4A4A4A);
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "accessibilityMoxColor",
+            name = "MOX colour",
+            description = "Colour for MOX resin (blocks, lever, progress bar) when accessibility mode is on",
+            position = 4
+    )
+    default Color accessibilityMoxColor() {
+        return new Color(0x9D4EDD);
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "accessibilityAgaColor",
+            name = "AGA colour",
+            description = "Colour for AGA resin (blocks, lever, progress bar) when accessibility mode is on",
+            position = 5
+    )
+    default Color accessibilityAgaColor() {
+        return new Color(0x00FFB3);
+    }
+
+    @ConfigItem(
+            section = ACCESSIBILITY,
+            keyName = "accessibilityLyeColor",
+            name = "LYE colour",
+            description = "Colour for LYE resin (blocks, lever, progress bar) when accessibility mode is on",
+            position = 6
+    )
+    default Color accessibilityLyeColor() {
+        return new Color(0xFF6D00);
     }
 }

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -34,6 +34,16 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "dyslexicMixology",
+            name = "Dyslexic Mixology",
+            description = "Replace M/A/L letters with solid colour blocks in the order list and inventory tags",
+            position = 1
+    )
+    default boolean dyslexicMixology() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
             description = "Determines how potion orders are sorted in the interface",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -137,6 +137,8 @@ public class MasteringMixologyPlugin extends Plugin {
     private int agitatorQuickActionTicks = 0;
     private int alembicQuickActionTicks = 0;
 
+    private boolean previouslyAboveRewardThreshold = false;
+
     private final Goal goal = new Goal(RewardItem.NONE);
 
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
@@ -167,6 +169,7 @@ public class MasteringMixologyPlugin extends Plugin {
         overlayManager.add(overlay);
         overlayManager.add(potionOverlay);
         overlayManager.add(goalInfoBoxOverlay);
+        previouslyAboveRewardThreshold = false;
 
         if (client.getGameState() == GameState.LOGGED_IN) {
             clientThread.invokeLater(this::initialize);
@@ -236,8 +239,9 @@ public class MasteringMixologyPlugin extends Plugin {
             unHighlightObject(AlchemyObject.DIGWEED_NORTH_WEST);
         }
 
-        if (event.getKey().equals("selectedReward") || event.getKey().equals("rewardQuantity") || event.getKey().equals("showResinBars")) {
+        if (event.getKey().equals("showResinBars") || event.getKey().startsWith("track") || event.getKey().endsWith("Quantity")) {
             recalculateGoalData();
+            previouslyAboveRewardThreshold = false;
         }
 
         if (config.highlightLevers()) {
@@ -394,7 +398,25 @@ public class MasteringMixologyPlugin extends Plugin {
             resetStationHighlight(AlchemyObject.ALEMBIC);
         } else if (varpId == VARP_MOX_RESIN || varpId == VARP_AGA_RESIN || varpId == VARP_LYE_RESIN) {
             recalculateGoalData();
+            checkRewardThresholdNotification();
         }
+    }
+
+    private void checkRewardThresholdNotification() {
+        if (!goal.isMultiMode()) {
+            previouslyAboveRewardThreshold = false;
+            return;
+        }
+        // Goal already summed the costs (including per-pack quantities) and
+        // computed per-component progress. overallProgress is the mean of
+        // each component's clamped percentage, so it reaches 1.0 only when
+        // every component meets its summed goal.
+        boolean nowAbove = goal.getOverallProgress() >= 1.0;
+        if (nowAbove && !previouslyAboveRewardThreshold) {
+            notifier.notify(config.thresholdNotification(),
+                    "You have enough resin to purchase your selected Mastering Mixology rewards.");
+        }
+        previouslyAboveRewardThreshold = nowAbove;
     }
 
     @Subscribe

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -141,6 +142,8 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private final Goal goal = new Goal(RewardItem.NONE);
 
+    private final MetaPolicy metaPolicy = new MetaPolicy();
+
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
     }
@@ -170,6 +173,7 @@ public class MasteringMixologyPlugin extends Plugin {
         overlayManager.add(potionOverlay);
         overlayManager.add(goalInfoBoxOverlay);
         previouslyAboveRewardThreshold = false;
+        metaPolicy.reset();
 
         if (client.getGameState() == GameState.LOGGED_IN) {
             clientThread.invokeLater(this::initialize);
@@ -242,6 +246,16 @@ public class MasteringMixologyPlugin extends Plugin {
         if (event.getKey().equals("showResinBars") || event.getKey().startsWith("track") || event.getKey().endsWith("Quantity")) {
             recalculateGoalData();
             previouslyAboveRewardThreshold = false;
+        }
+
+        // Re-decorate orders when any highlight-related setting changes so
+        // the player sees the effect immediately without waiting for the
+        // next order rebuild.
+        if (event.getKey().equals("highlightRecommendedPotions")
+                || event.getKey().equals("recommendedPotionColor")
+                || event.getKey().equals("notRecommendedPotionColor")) {
+            metaPolicy.reset();
+            clientThread.invokeLater(this::triggerPotionOrderUpdate);
         }
 
         if (config.highlightLevers()) {
@@ -480,6 +494,13 @@ public class MasteringMixologyPlugin extends Plugin {
         if (children.isEmpty()) {
             return;
         }
+
+        // Compute the meta-policy recommendation once per rebuild (the orders
+        // and the resin state are both stable until the next refresh). null
+        // means "highlighting disabled" -- e.g. toggle off or no rewards
+        // tracked yet.
+        Set<Integer> recommendedSlots = computeRecommendedSlots();
+
         /*
          * Filtered children layout:
          * TEXT - Potion Orders
@@ -509,6 +530,13 @@ public class MasteringMixologyPlugin extends Plugin {
             }
             orderText.setText(builder.toString());
 
+            if (recommendedSlots != null && !order.fulfilled()) {
+                Color tint = recommendedSlots.contains(order.idx())
+                        ? config.recommendedPotionColor()
+                        : config.notRecommendedPotionColor();
+                orderText.setTextColor(tint.getRGB());
+            }
+
             if (i != order.idx()) {
                 LOGGER.debug("Updating order {} position from {} to {}", order, order.idx(), i);
                 // update component position
@@ -520,6 +548,48 @@ public class MasteringMixologyPlugin extends Plugin {
                 orderText.revalidate();
             }
         }
+    }
+
+    /**
+     * Returns the order indices the adaptive meta-policy recommends brewing
+     * this turn, or null if highlighting is disabled (config off, no
+     * rewards selected, or order data missing).
+     */
+    private Set<Integer> computeRecommendedSlots() {
+        if (!config.highlightRecommendedPotions()) {
+            return null;
+        }
+        if (potionOrders.size() != 3) {
+            return null;
+        }
+        // Target = sum of selected reward costs (the Goal already handles
+        // this for the overlay / threshold notification).
+        if (!goal.isMultiMode()) {
+            return null;
+        }
+        var mox = goal.getComponentData(MOX);
+        var aga = goal.getComponentData(AGA);
+        var lye = goal.getComponentData(LYE);
+        if (mox == null || aga == null || lye == null) {
+            return null;
+        }
+        int[] resin = {
+                client.getVarpValue(VARP_MOX_RESIN),
+                client.getVarpValue(VARP_AGA_RESIN),
+                client.getVarpValue(VARP_LYE_RESIN)
+        };
+        int[] target = { mox.goalAmount, aga.goalAmount, lye.goalAmount };
+        if (target[0] == 0 && target[1] == 0 && target[2] == 0) {
+            return null;
+        }
+        // Build the 3-slot PotionType array in original conveyor order.
+        // potionOrders may be sorted by config.potionOrderSorting() so we
+        // re-index by order.idx().
+        PotionType[] ordersBySlot = new PotionType[3];
+        for (PotionOrder po : potionOrders) {
+            ordersBySlot[po.idx()] = po.potionType();
+        }
+        return metaPolicy.decide(ordersBySlot, resin, target);
     }
 
     private List<Widget> selectChildren(Widget parent, Predicate<Widget> filter) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -526,7 +526,10 @@ public class MasteringMixologyPlugin extends Plugin {
             if (order.fulfilled()) {
                 builder.append(" (<col=00ff00>done!</col>)");
             } else {
-                builder.append(" (").append(order.potionType().recipe()).append(")");
+                String recipe = config.dyslexicMixology()
+                        ? order.potionType().recipeBlocks()
+                        : order.potionType().recipe();
+                builder.append(" (").append(recipe).append(")");
             }
             orderText.setText(builder.toString());
 

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -145,6 +145,7 @@ public class MasteringMixologyPlugin extends Plugin {
     private final MetaPolicy metaPolicy = new MetaPolicy();
 
     private int[] resinIconIdx = null;
+    private net.runelite.api.IndexedSprite[] resinIconSprites = null;
 
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
@@ -185,6 +186,7 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private void registerResinIcons() {
         if (resinIconIdx != null) {
+            applyResinIconPalettes();
             return;
         }
         net.runelite.api.IndexedSprite[] mod = client.getModIcons();
@@ -195,6 +197,7 @@ public class MasteringMixologyPlugin extends Plugin {
         int base = mod.length;
         net.runelite.api.IndexedSprite[] extended = Arrays.copyOf(mod, base + 3);
         int[] indices = new int[3];
+        net.runelite.api.IndexedSprite[] sprites = new net.runelite.api.IndexedSprite[3];
         for (PotionComponent c : PotionComponent.ENTRIES) {
             net.runelite.api.IndexedSprite s = client.createIndexedSprite();
             byte[] pixels = new byte[size * size];
@@ -205,16 +208,42 @@ public class MasteringMixologyPlugin extends Plugin {
                 pixels[i] = (byte) (edge ? 1 : 2);
             }
             s.setPixels(pixels);
-            s.setPalette(new int[]{0, 0x000000, c.color().getRGB() & 0xFFFFFF});
+            s.setPalette(new int[]{0, 0x000000, effectiveComponentColor(c).getRGB() & 0xFFFFFF});
             s.setWidth(size);
             s.setHeight(size);
             s.setOriginalWidth(size);
             s.setOriginalHeight(size);
             extended[base + c.ordinal()] = s;
             indices[c.ordinal()] = base + c.ordinal();
+            sprites[c.ordinal()] = s;
         }
         client.setModIcons(extended);
         resinIconIdx = indices;
+        resinIconSprites = sprites;
+    }
+
+    private void applyResinIconPalettes() {
+        if (resinIconSprites == null) {
+            return;
+        }
+        for (PotionComponent c : PotionComponent.ENTRIES) {
+            net.runelite.api.IndexedSprite s = resinIconSprites[c.ordinal()];
+            if (s != null) {
+                s.setPalette(new int[]{0, 0x000000, effectiveComponentColor(c).getRGB() & 0xFFFFFF});
+            }
+        }
+    }
+
+    Color effectiveComponentColor(PotionComponent c) {
+        if (!config.accessibilityMode()) {
+            return c.color();
+        }
+        switch (c) {
+            case MOX: return config.accessibilityMoxColor();
+            case AGA: return config.accessibilityAgaColor();
+            case LYE: return config.accessibilityLyeColor();
+            default:  return c.color();
+        }
     }
 
     @Override
@@ -290,9 +319,22 @@ public class MasteringMixologyPlugin extends Plugin {
         // next order rebuild.
         if (event.getKey().equals("highlightRecommendedPotions")
                 || event.getKey().equals("recommendedPotionColor")
-                || event.getKey().equals("notRecommendedPotionColor")) {
+                || event.getKey().equals("notRecommendedPotionColor")
+                || event.getKey().equals("dyslexicMixology")
+                || event.getKey().equals("accessibilityRecommendColor")
+                || event.getKey().equals("accessibilitySkipColor")) {
             metaPolicy.reset();
             clientThread.invokeLater(this::triggerPotionOrderUpdate);
+        }
+
+        if (event.getKey().equals("dyslexicMixology")
+                || event.getKey().equals("accessibilityMoxColor")
+                || event.getKey().equals("accessibilityAgaColor")
+                || event.getKey().equals("accessibilityLyeColor")) {
+            clientThread.invokeLater(this::applyResinIconPalettes);
+            if (config.highlightLevers()) {
+                clientThread.invokeLater(this::highlightLevers);
+            }
         }
 
         if (config.highlightLevers()) {
@@ -563,7 +605,7 @@ public class MasteringMixologyPlugin extends Plugin {
             if (order.fulfilled()) {
                 builder.append(" (<col=00ff00>done!</col>)");
             } else {
-                String recipe = (config.dyslexicMixology() && resinIconIdx != null)
+                String recipe = (config.accessibilityMode() && resinIconIdx != null)
                         ? order.potionType().recipeBlocks(resinIconIdx)
                         : order.potionType().recipe();
                 builder.append(" (").append(recipe).append(")");
@@ -571,9 +613,13 @@ public class MasteringMixologyPlugin extends Plugin {
             orderText.setText(builder.toString());
 
             if (recommendedSlots != null && !order.fulfilled()) {
-                Color tint = recommendedSlots.contains(order.idx())
-                        ? config.recommendedPotionColor()
-                        : config.notRecommendedPotionColor();
+                boolean recommended = recommendedSlots.contains(order.idx());
+                Color tint;
+                if (config.accessibilityMode()) {
+                    tint = recommended ? config.accessibilityRecommendColor() : config.accessibilitySkipColor();
+                } else {
+                    tint = recommended ? config.recommendedPotionColor() : config.notRecommendedPotionColor();
+                }
                 orderText.setTextColor(tint.getRGB());
             }
 
@@ -722,9 +768,9 @@ public class MasteringMixologyPlugin extends Plugin {
             return;
         }
 
-        highlightObject(LYE_LEVER, LYE.color());
-        highlightObject(AGA_LEVER, AGA.color());
-        highlightObject(MOX_LEVER, MOX.color());
+        highlightObject(LYE_LEVER, effectiveComponentColor(LYE));
+        highlightObject(AGA_LEVER, effectiveComponentColor(AGA));
+        highlightObject(MOX_LEVER, effectiveComponentColor(MOX));
     }
 
     private void unHighlightLevers() {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -144,6 +144,8 @@ public class MasteringMixologyPlugin extends Plugin {
 
     private final MetaPolicy metaPolicy = new MetaPolicy();
 
+    private int[] resinIconIdx = null;
+
     public Map<AlchemyObject, HighlightedObject> highlightedObjects() {
         return highlightedObjects;
     }
@@ -174,10 +176,45 @@ public class MasteringMixologyPlugin extends Plugin {
         overlayManager.add(goalInfoBoxOverlay);
         previouslyAboveRewardThreshold = false;
         metaPolicy.reset();
+        clientThread.invokeLater(this::registerResinIcons);
 
         if (client.getGameState() == GameState.LOGGED_IN) {
             clientThread.invokeLater(this::initialize);
         }
+    }
+
+    private void registerResinIcons() {
+        if (resinIconIdx != null) {
+            return;
+        }
+        net.runelite.api.IndexedSprite[] mod = client.getModIcons();
+        if (mod == null) {
+            return;
+        }
+        final int size = 9;
+        int base = mod.length;
+        net.runelite.api.IndexedSprite[] extended = Arrays.copyOf(mod, base + 3);
+        int[] indices = new int[3];
+        for (PotionComponent c : PotionComponent.ENTRIES) {
+            net.runelite.api.IndexedSprite s = client.createIndexedSprite();
+            byte[] pixels = new byte[size * size];
+            for (int i = 0; i < pixels.length; i++) {
+                int x = i % size;
+                int y = i / size;
+                boolean edge = x == 0 || x == size - 1 || y == 0 || y == size - 1;
+                pixels[i] = (byte) (edge ? 1 : 2);
+            }
+            s.setPixels(pixels);
+            s.setPalette(new int[]{0, 0x000000, c.color().getRGB() & 0xFFFFFF});
+            s.setWidth(size);
+            s.setHeight(size);
+            s.setOriginalWidth(size);
+            s.setOriginalHeight(size);
+            extended[base + c.ordinal()] = s;
+            indices[c.ordinal()] = base + c.ordinal();
+        }
+        client.setModIcons(extended);
+        resinIconIdx = indices;
     }
 
     @Override
@@ -526,8 +563,8 @@ public class MasteringMixologyPlugin extends Plugin {
             if (order.fulfilled()) {
                 builder.append(" (<col=00ff00>done!</col>)");
             } else {
-                String recipe = config.dyslexicMixology()
-                        ? order.potionType().recipeBlocks()
+                String recipe = (config.dyslexicMixology() && resinIconIdx != null)
+                        ? order.potionType().recipeBlocks(resinIconIdx)
                         : order.potionType().recipe();
                 builder.append(" (").append(recipe).append(")");
             }

--- a/src/main/java/work/fking/masteringmixology/MetaPolicy.java
+++ b/src/main/java/work/fking/masteringmixology/MetaPolicy.java
@@ -25,8 +25,8 @@ public class MetaPolicy {
     /** Recommended thresholds from the sweep at 61k/53k/71k. See STRATEGY.md §7. */
     public static final double T_DUAL_IN       = 0.20;
     public static final double T_DUAL_OUT      = 0.25;
-    public static final double T_BALANCED_IN   = 0.10;
-    public static final double T_BALANCED_OUT  = 0.15;
+    public static final double T_BALANCED_IN   = 0.20;
+    public static final double T_BALANCED_OUT  = 0.25;
 
     private State state = State.SINGLE_BN;
 

--- a/src/main/java/work/fking/masteringmixology/MetaPolicy.java
+++ b/src/main/java/work/fking/masteringmixology/MetaPolicy.java
@@ -205,20 +205,33 @@ public class MetaPolicy {
 
     /**
      * Deficit-reduction score for a slot: sum over colours of
-     * resin_in_color * max(deficit_color, 0). Each unique component in the
-     * potion's recipe yields 10 resin in that colour.
+     * resin_in_color * max(deficit_color, 0). Resin yield per potion:
+     *   XXX (single component repeated 3x)     -> 20 of X
+     *   XXY (one component doubled, one single)-> 20 of doubled + 10 of single
+     *   XYZ (three distinct components = MAL)  -> 20 of each
      */
     private static int slotScore(PotionType pt, int[] deficit) {
         if (pt == null) {
             return Integer.MIN_VALUE;
         }
-        EnumSet<PotionComponent> uniq = EnumSet.noneOf(PotionComponent.class);
+        int[] count = new int[3];
         for (PotionComponent c : pt.components()) {
-            uniq.add(c);
+            count[c.ordinal()]++;
+        }
+        int distinct = 0;
+        for (int c = 0; c < 3; c++) {
+            if (count[c] > 0) {
+                distinct++;
+            }
         }
         int score = 0;
-        for (PotionComponent c : uniq) {
-            score += 10 * Math.max(deficit[c.ordinal()], 0);
+        for (int c = 0; c < 3; c++) {
+            if (count[c] == 0) {
+                continue;
+            }
+            // XXY single colour gets 10; otherwise 20 (XXX, XXY's doubled, all of MAL).
+            int yield = (count[c] == 1 && distinct == 2) ? 10 : 20;
+            score += yield * Math.max(deficit[c], 0);
         }
         return score;
     }

--- a/src/main/java/work/fking/masteringmixology/MetaPolicy.java
+++ b/src/main/java/work/fking/masteringmixology/MetaPolicy.java
@@ -1,0 +1,252 @@
+package work.fking.masteringmixology;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Adaptive meta-policy that decides which of the 3 visible orders the
+ * player should brew this turn. Implements the state machine documented in
+ * {@code mixology-sim/STRATEGY.md} §7 with the recommended thresholds.
+ *
+ * <p>State is maintained across calls so the policy can detect when the
+ * deficit shape transitions between (single-bottleneck / two-bottleneck /
+ * balanced) regimes and switch sub-policy accordingly. Call {@link #reset()}
+ * at the start of a fresh session (player enters the lab, plugin starts up).
+ *
+ * <p>The decision returned is the set of order indices (0..2) the player
+ * should brew. The plugin maps that to UI colouring (green vs red text).
+ */
+public class MetaPolicy {
+
+    public enum State { SINGLE_BN, DUAL_BN, BALANCED }
+
+    /** Recommended thresholds from the sweep at 61k/53k/71k. See STRATEGY.md §7. */
+    public static final double T_DUAL_IN       = 0.20;
+    public static final double T_DUAL_OUT      = 0.25;
+    public static final double T_BALANCED_IN   = 0.10;
+    public static final double T_BALANCED_OUT  = 0.15;
+
+    private State state = State.SINGLE_BN;
+
+    public void reset() {
+        state = State.SINGLE_BN;
+    }
+
+    public State currentState() {
+        return state;
+    }
+
+    /**
+     * Decide which slots to brew.
+     *
+     * @param orders     the 3 current orders' PotionTypes (slot index = array index)
+     * @param resin      [mox, aga, lye] current resin from varps
+     * @param target     [mox, aga, lye] total target (sum of selected reward costs)
+     * @return set of order indices (0..2) the player should brew this turn
+     */
+    public Set<Integer> decide(PotionType[] orders, int[] resin, int[] target) {
+        int[] deficit = new int[3];
+        for (int c = 0; c < 3; c++) {
+            deficit[c] = Math.max(target[c] - resin[c], 0);
+        }
+
+        // Top-2 deficit indices (R's order(..., decreasing=TRUE) tie-break:
+        // lower original index first). Stable sort with deficit-desc primary,
+        // index-asc secondary matches.
+        Integer[] colorIdx = {0, 1, 2};
+        Arrays.sort(colorIdx, (a, b) -> {
+            int cmp = Integer.compare(deficit[b], deficit[a]);
+            return cmp != 0 ? cmp : Integer.compare(a, b);
+        });
+        int dMax = deficit[colorIdx[0]];
+        int dMid = deficit[colorIdx[1]];
+        int dMin = deficit[colorIdx[2]];
+
+        double gap12 = dMax == 0 ? Double.POSITIVE_INFINITY : (dMax - dMid) / (double) dMax;
+        double gap13 = dMax == 0 ? Double.POSITIVE_INFINITY : (dMax - dMin) / (double) dMax;
+
+        // State transition (with hysteresis). When leaving balanced, the next
+        // state is dual_bn if the top-2 are still tight, single_bn otherwise.
+        switch (state) {
+            case SINGLE_BN:
+                if (gap13 < T_BALANCED_IN) {
+                    state = State.BALANCED;
+                } else if (gap12 < T_DUAL_IN) {
+                    state = State.DUAL_BN;
+                }
+                break;
+            case DUAL_BN:
+                if (gap13 < T_BALANCED_IN) {
+                    state = State.BALANCED;
+                } else if (gap12 > T_DUAL_OUT) {
+                    state = State.SINGLE_BN;
+                }
+                break;
+            case BALANCED:
+                if (gap13 > T_BALANCED_OUT) {
+                    state = (gap12 < T_DUAL_IN) ? State.DUAL_BN : State.SINGLE_BN;
+                }
+                break;
+        }
+
+        switch (state) {
+            case SINGLE_BN:
+                return singleBn(orders, deficit, colorIdx[0]);
+            case DUAL_BN:
+                return dualBn(orders, deficit, colorIdx[0], colorIdx[1]);
+            case BALANCED:
+            default:
+                return balanced(orders, deficit);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Sub-policies
+    // ------------------------------------------------------------------
+
+    /**
+     * single_bn: if ≥2 of the 3 orders give the top-deficit colour, brew all
+     * 3; else brew the slots that give that colour; else brew the single
+     * best-deficit slot.
+     */
+    private Set<Integer> singleBn(PotionType[] orders, int[] deficit, int topColorOrd) {
+        PotionComponent top = PotionComponent.ENTRIES[topColorOrd];
+        Set<Integer> giving = slotsGiving(orders, top);
+        if (giving.size() >= 2) {
+            return all3();
+        }
+        if (!giving.isEmpty()) {
+            return giving;
+        }
+        return singleton(bestDeficitSlot(orders, deficit));
+    }
+
+    /**
+     * dual_bn: if ≥2 of the 3 orders give *both* top-2 deficit colours, brew
+     * all 3; else fall through to the single_bn rule.
+     */
+    private Set<Integer> dualBn(PotionType[] orders, int[] deficit, int topOrd, int midOrd) {
+        PotionComponent top = PotionComponent.ENTRIES[topOrd];
+        PotionComponent mid = PotionComponent.ENTRIES[midOrd];
+        if (countSlotsGivingBoth(orders, top, mid) >= 2) {
+            return all3();
+        }
+        return singleBn(orders, deficit, topOrd);
+    }
+
+    /**
+     * balanced: if all 3 orders are multi-resin (not MMM/AAA/LLL), brew all
+     * 3; else brew the single best-deficit slot.
+     */
+    private Set<Integer> balanced(PotionType[] orders, int[] deficit) {
+        if (allMultiResin(orders)) {
+            return all3();
+        }
+        return singleton(bestDeficitSlot(orders, deficit));
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static boolean givesResin(PotionType pt, PotionComponent color) {
+        if (pt == null) {
+            return false;
+        }
+        for (PotionComponent c : pt.components()) {
+            if (c == color) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<Integer> slotsGiving(PotionType[] orders, PotionComponent color) {
+        Set<Integer> result = new HashSet<>();
+        for (int i = 0; i < orders.length; i++) {
+            if (givesResin(orders[i], color)) {
+                result.add(i);
+            }
+        }
+        return result;
+    }
+
+    private static int countSlotsGivingBoth(PotionType[] orders, PotionComponent a, PotionComponent b) {
+        int count = 0;
+        for (PotionType pt : orders) {
+            if (givesResin(pt, a) && givesResin(pt, b)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isMultiResin(PotionType pt) {
+        if (pt == null) {
+            return false;
+        }
+        EnumSet<PotionComponent> uniq = EnumSet.noneOf(PotionComponent.class);
+        for (PotionComponent c : pt.components()) {
+            uniq.add(c);
+        }
+        return uniq.size() >= 2;
+    }
+
+    private static boolean allMultiResin(PotionType[] orders) {
+        for (PotionType pt : orders) {
+            if (!isMultiResin(pt)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Deficit-reduction score for a slot: sum over colours of
+     * resin_in_color * max(deficit_color, 0). Each unique component in the
+     * potion's recipe yields 10 resin in that colour.
+     */
+    private static int slotScore(PotionType pt, int[] deficit) {
+        if (pt == null) {
+            return Integer.MIN_VALUE;
+        }
+        EnumSet<PotionComponent> uniq = EnumSet.noneOf(PotionComponent.class);
+        for (PotionComponent c : pt.components()) {
+            uniq.add(c);
+        }
+        int score = 0;
+        for (PotionComponent c : uniq) {
+            score += 10 * Math.max(deficit[c.ordinal()], 0);
+        }
+        return score;
+    }
+
+    private static int bestDeficitSlot(PotionType[] orders, int[] deficit) {
+        int bestIdx = 0;
+        int bestScore = Integer.MIN_VALUE;
+        for (int i = 0; i < orders.length; i++) {
+            int s = slotScore(orders[i], deficit);
+            if (s > bestScore) {
+                bestScore = s;
+                bestIdx = i;
+            }
+        }
+        return bestIdx;
+    }
+
+    private static Set<Integer> all3() {
+        Set<Integer> s = new HashSet<>(3);
+        s.add(0);
+        s.add(1);
+        s.add(2);
+        return s;
+    }
+
+    private static Set<Integer> singleton(int idx) {
+        Set<Integer> s = new HashSet<>(1);
+        s.add(idx);
+        return s;
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/MetaPolicy.java
+++ b/src/main/java/work/fking/masteringmixology/MetaPolicy.java
@@ -137,11 +137,15 @@ public class MetaPolicy {
     }
 
     /**
-     * balanced: if all 3 orders are multi-resin (not MMM/AAA/LLL), brew all
-     * 3; else brew the single best-deficit slot.
+     * balanced: if any order is MAL (gives all three colours) OR all 3 orders
+     * are multi-resin (not MMM/AAA/LLL), brew all 3; else brew the single
+     * best-deficit slot. The MAL trigger captures the case where a single
+     * three-colour potion is enough to justify a 3-batch even when the other
+     * slots are singletons -- the +0.4 batch bonus on MAL alone gives 28 of
+     * every colour, outweighing the overshoot from the singleton partners.
      */
     private Set<Integer> balanced(PotionType[] orders, int[] deficit) {
-        if (allMultiResin(orders)) {
+        if (anyMal(orders) || allMultiResin(orders)) {
             return all3();
         }
         return singleton(bestDeficitSlot(orders, deficit));
@@ -201,6 +205,26 @@ public class MetaPolicy {
             }
         }
         return true;
+    }
+
+    private static boolean isMal(PotionType pt) {
+        if (pt == null) {
+            return false;
+        }
+        EnumSet<PotionComponent> uniq = EnumSet.noneOf(PotionComponent.class);
+        for (PotionComponent c : pt.components()) {
+            uniq.add(c);
+        }
+        return uniq.size() == 3;
+    }
+
+    private static boolean anyMal(PotionType[] orders) {
+        for (PotionType pt : orders) {
+            if (isMal(pt)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/work/fking/masteringmixology/OutlinedProgressBarComponent.java
+++ b/src/main/java/work/fking/masteringmixology/OutlinedProgressBarComponent.java
@@ -1,0 +1,118 @@
+package work.fking.masteringmixology;
+
+import net.runelite.client.ui.overlay.components.ComponentConstants;
+import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
+import net.runelite.client.ui.overlay.components.TextComponent;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+
+// Progress bar with outlined text. Mirrors ProgressBarComponent's interface
+// but renders each label via TextComponent with setOutline(true) so the
+// text stays readable over the coloured bar fill.
+class OutlinedProgressBarComponent implements LayoutableRenderableEntity {
+
+    private static final int BAR_HEIGHT = 16;
+    private static final int TEXT_PADDING = 4;
+
+    private double value = 0.0;
+    private String leftLabel = "";
+    private String centerLabel = "";
+    private String rightLabel = "";
+    private Color foregroundColor = Color.GREEN;
+    private Color backgroundColor = new Color(61, 56, 49);
+    private Color fontColor = Color.WHITE;
+
+    private Point preferredLocation = new Point();
+    private Dimension preferredSize = new Dimension(ComponentConstants.STANDARD_WIDTH, BAR_HEIGHT);
+    private final Rectangle bounds = new Rectangle();
+
+    void setValue(double value) {
+        this.value = Math.max(0, Math.min(100, value));
+    }
+
+    void setLeftLabel(String s) {
+        this.leftLabel = s == null ? "" : s;
+    }
+
+    void setCenterLabel(String s) {
+        this.centerLabel = s == null ? "" : s;
+    }
+
+    void setRightLabel(String s) {
+        this.rightLabel = s == null ? "" : s;
+    }
+
+    void setForegroundColor(Color c) {
+        this.foregroundColor = c;
+    }
+
+    void setBackgroundColor(Color c) {
+        this.backgroundColor = c;
+    }
+
+    void setFontColor(Color c) {
+        this.fontColor = c;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        int x = preferredLocation.x;
+        int y = preferredLocation.y;
+        int width = preferredSize.width;
+        int height = preferredSize.height > 0 ? preferredSize.height : BAR_HEIGHT;
+
+        graphics.setColor(backgroundColor);
+        graphics.fillRect(x, y, width, height);
+
+        int fgWidth = (int) (width * value / 100.0);
+        graphics.setColor(foregroundColor);
+        graphics.fillRect(x, y, fgWidth, height);
+
+        FontMetrics fm = graphics.getFontMetrics();
+        int textY = y + (height + fm.getAscent()) / 2 - 1;
+
+        if (!leftLabel.isEmpty()) {
+            drawOutlined(graphics, leftLabel, x + TEXT_PADDING, textY);
+        }
+        if (!centerLabel.isEmpty()) {
+            int w = fm.stringWidth(centerLabel);
+            drawOutlined(graphics, centerLabel, x + (width - w) / 2, textY);
+        }
+        if (!rightLabel.isEmpty()) {
+            int w = fm.stringWidth(rightLabel);
+            drawOutlined(graphics, rightLabel, x + width - w - TEXT_PADDING, textY);
+        }
+
+        bounds.setBounds(x, y, width, height);
+        return new Dimension(width, height);
+    }
+
+    private void drawOutlined(Graphics2D graphics, String text, int x, int y) {
+        TextComponent t = new TextComponent();
+        t.setText(text);
+        t.setColor(fontColor);
+        t.setOutline(true);
+        t.setPosition(new Point(x, y));
+        t.render(graphics);
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        return bounds;
+    }
+
+    @Override
+    public void setPreferredLocation(Point preferredLocation) {
+        this.preferredLocation = preferredLocation;
+    }
+
+    @Override
+    public void setPreferredSize(Dimension preferredSize) {
+        this.preferredSize = preferredSize;
+    }
+}

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -38,7 +38,6 @@ public enum PotionType {
     private final int itemId;
     private final int modifiedItemId;
     private final String recipe;
-    private final String recipeBlocks;
     private final String abbreviation;
     private final int experience;
     private final PotionComponent[] components;
@@ -47,8 +46,7 @@ public enum PotionType {
     PotionType(int itemId, int modifiedItemId, int experience, PotionComponent... components) {
         this.itemId = itemId;
         this.modifiedItemId = modifiedItemId;
-        this.recipe = colorizeRecipe(components, false);
-        this.recipeBlocks = colorizeRecipe(components, true);
+        this.recipe = colorizeRecipe(components);
         this.experience = experience;
         this.components = components;
         this.abbreviation = "" + components[0].character() + components[1].character() + components[2].character();
@@ -65,18 +63,25 @@ public enum PotionType {
         return TYPES[potionTypeId];
     }
 
-    private static String colorizeRecipe(PotionComponent[] components, boolean blocks) {
+    private static String colorizeRecipe(PotionComponent[] components) {
         if (components.length != 3) {
             throw new IllegalArgumentException("Invalid potion components: " + Arrays.toString(components));
         }
-        return colorizeRecipeComponent(components[0], blocks)
-                + colorizeRecipeComponent(components[1], blocks)
-                + colorizeRecipeComponent(components[2], blocks);
+        return colorizeRecipeComponent(components[0])
+                + colorizeRecipeComponent(components[1])
+                + colorizeRecipeComponent(components[2]);
     }
 
-    private static String colorizeRecipeComponent(PotionComponent component, boolean blocks) {
-        char glyph = blocks ? '█' : component.character();
-        return "<col=" + component.colorCode() + ">" + glyph + "</col>";
+    private static String colorizeRecipeComponent(PotionComponent component) {
+        return "<col=" + component.colorCode() + ">" + component.character() + "</col>";
+    }
+
+    public String recipeBlocks(int[] iconIdx) {
+        StringBuilder sb = new StringBuilder(18);
+        for (PotionComponent c : components) {
+            sb.append("<img=").append(iconIdx[c.ordinal()]).append('>');
+        }
+        return sb.toString();
     }
 
     public int itemId() {
@@ -89,10 +94,6 @@ public enum PotionType {
 
     public String recipe() {
         return recipe;
-    }
-
-    public String recipeBlocks() {
-        return recipeBlocks;
     }
 
     public int experience() {

--- a/src/main/java/work/fking/masteringmixology/PotionType.java
+++ b/src/main/java/work/fking/masteringmixology/PotionType.java
@@ -38,6 +38,7 @@ public enum PotionType {
     private final int itemId;
     private final int modifiedItemId;
     private final String recipe;
+    private final String recipeBlocks;
     private final String abbreviation;
     private final int experience;
     private final PotionComponent[] components;
@@ -46,7 +47,8 @@ public enum PotionType {
     PotionType(int itemId, int modifiedItemId, int experience, PotionComponent... components) {
         this.itemId = itemId;
         this.modifiedItemId = modifiedItemId;
-        this.recipe = colorizeRecipe(components);
+        this.recipe = colorizeRecipe(components, false);
+        this.recipeBlocks = colorizeRecipe(components, true);
         this.experience = experience;
         this.components = components;
         this.abbreviation = "" + components[0].character() + components[1].character() + components[2].character();
@@ -63,17 +65,18 @@ public enum PotionType {
         return TYPES[potionTypeId];
     }
 
-    private static String colorizeRecipe(PotionComponent[] components) {
+    private static String colorizeRecipe(PotionComponent[] components, boolean blocks) {
         if (components.length != 3) {
             throw new IllegalArgumentException("Invalid potion components: " + Arrays.toString(components));
         }
-        return colorizeRecipeComponent(components[0])
-                + colorizeRecipeComponent(components[1])
-                + colorizeRecipeComponent(components[2]);
+        return colorizeRecipeComponent(components[0], blocks)
+                + colorizeRecipeComponent(components[1], blocks)
+                + colorizeRecipeComponent(components[2], blocks);
     }
 
-    private static String colorizeRecipeComponent(PotionComponent component) {
-        return "<col=" + component.colorCode() + ">" + component.character() + "</col>";
+    private static String colorizeRecipeComponent(PotionComponent component, boolean blocks) {
+        char glyph = blocks ? '█' : component.character();
+        return "<col=" + component.colorCode() + ">" + glyph + "</col>";
     }
 
     public int itemId() {
@@ -86,6 +89,10 @@ public enum PotionType {
 
     public String recipe() {
         return recipe;
+    }
+
+    public String recipeBlocks() {
+        return recipeBlocks;
     }
 
     public int experience() {


### PR DESCRIPTION
## Summary

Replaces the single **Selected Reward** / **Reward Quantity** dropdown in the Reward Tracking section with a per-reward checkbox model, and adds a `Notification` that fires once when the player has earned enough resin to purchase every selected reward at once.

## What changed

**Config** (`MasteringMixologyConfig`)
- Removed: `selectedReward`, `rewardQuantity`
- Added: per-reward `trackX` booleans for all 12 rewards (8 one-time + 4 repeatable)
- Added: a `qty` int for each repeatable reward (Apprentice / Adept / Expert Potion Pack, Aldarium)
- Added: `thresholdNotification` (`Notification`, default `OFF`)
- The old `Reward Threshold` section has been merged into `Reward Tracking` so everything lives in one place.

**Goal** (`Goal.java`)
- `recalculate()` now sums the cost of every ticked reward (multiplied by its quantity for repeatables) and uses that as the goal across all three components.
- New `displayName` / `isMultiMode()` accessors so the overlay can label the panel with either the single reward name or `Selected rewards (N)`.

**Plugin** (`MasteringMixologyPlugin`)
- `onVarbitChanged` now calls a `checkRewardThresholdNotification()` after recalculating goal data. The helper fires the notification once on the upward crossing (when `goal.getOverallProgress() >= 1.0`); a `previouslyAboveRewardThreshold` flag prevents repeat firings while the player stays above the line.
- The flag resets on `startUp()` and on any `track*` / `*Quantity` config change so toggling selections re-arms the notification.

**Overlay** (`GoalInfoBoxOverlay`)
- Reads `goal.getDisplayName()` for the top line and respects `goal.isMultiMode()` for the visibility check. Renders identically to before for the single-reward case.

## Behavior

| State | Overlay | Notification |
|---|---|---|
| No checkboxes ticked | Hidden | Disabled |
| One reward ticked | Shows that reward's name (and ×N for repeatables) | Fires when its cost is met |
| Two or more ticked | "Selected rewards (N)" | Fires when the summed cost is met |

## Test plan

- [ ] Build with `gradlew build` (passes checkstyle + tests).
- [ ] Open the plugin's config: confirm the consolidated **Reward Tracking** section with a row per reward and quantity boxes for the four repeatables.
- [ ] Tick one non-repeatable reward, set `thresholdNotification = ON`. Brew potions until all three resin pools meet that reward's cost. Notification fires once. Earning more resin past the line does not re-fire.
- [ ] Tick two or more rewards. Verify the overlay shows the combined cost on each progress bar and the panel header reads "Selected rewards (N)".
- [ ] Tick a repeatable reward (e.g. Apprentice Pack) and set its qty to 5. Confirm the overlay shows 5× the per-pack cost.
- [ ] Untick everything: overlay hides, notification disabled.