### PR TITLE
Add inventory station tags for finished potions

### DIFF
--- a/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
+++ b/src/main/java/work/fking/masteringmixology/InventoryPotionOverlay.java
@@ -22,7 +22,7 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
 
     @Override
     public void renderItemOverlay(Graphics2D graphics2D, int itemId, WidgetItem widgetItem) {
-        if (!plugin.isInLab() || config.inventoryPotionTagType() == InventoryPotionTagType.NONE) {
+        if (!plugin.isInLab()) {
             return;
         }
 
@@ -33,17 +33,58 @@ public class InventoryPotionOverlay extends WidgetItemOverlay {
         }
 
         var bounds = widgetItem.getCanvasBounds();
-        var x = bounds.x + 5;
-        var y = bounds.y + 30;
 
-        drawRecipe(graphics2D, potion, x + 1, y + 1, Color.BLACK); // Drop shadow
+        // Recipe tag (bottom-left) — unchanged.
+        if (config.inventoryPotionTagType() != InventoryPotionTagType.NONE) {
+            var x = bounds.x + 5;
+            var y = bounds.y + 30;
 
-        if (config.inventoryPotionTagType() == InventoryPotionTagType.COLORED) {
-            drawRecipe(graphics2D, potion, x, y, null);
-            return;
+            drawRecipe(graphics2D, potion, x + 1, y + 1, Color.BLACK); // Drop shadow
+
+            if (config.inventoryPotionTagType() == InventoryPotionTagType.COLORED) {
+                drawRecipe(graphics2D, potion, x, y, null);
+            } else {
+                drawRecipe(graphics2D, potion, x, y, Color.WHITE);
+            }
         }
 
-        drawRecipe(graphics2D, potion, x, y, Color.WHITE);
+        // Station tag (top-left) — only on finished potions we've tagged with a station.
+        if (config.showStationTags()) {
+            var widget = widgetItem.getWidget();
+            if (widget != null) {
+                var modifier = plugin.stationTag(widget.getIndex());
+                if (modifier != null) {
+                    drawStationTag(graphics2D, modifier, bounds.x + 1, bounds.y + 10);
+                }
+            }
+        }
+    }
+
+    private void drawStationTag(Graphics2D graphics2D, PotionModifier modifier, int x, int y) {
+        String text = stationLabel(modifier);
+        graphics2D.setFont(FontManager.getRunescapeSmallFont());
+        graphics2D.setColor(Color.BLACK);
+        graphics2D.drawString(text, x + 1, y + 1); // Drop shadow
+        graphics2D.setColor(stationColor(modifier));
+        graphics2D.drawString(text, x, y);
+    }
+
+    private static String stationLabel(PotionModifier modifier) {
+        switch (modifier) {
+            case HOMOGENOUS:   return "Agi";
+            case CONCENTRATED: return "Ret";
+            case CRYSTALISED:  return "Ale";
+            default:           return "";
+        }
+    }
+
+    private static Color stationColor(PotionModifier modifier) {
+        switch (modifier) {
+            case HOMOGENOUS:   return new Color(120, 230, 120); // green
+            case CONCENTRATED: return new Color(255, 170, 90);  // orange
+            case CRYSTALISED:  return new Color(120, 200, 255); // cyan
+            default:           return Color.WHITE;
+        }
     }
 
     private void drawRecipe(Graphics2D graphics2D, PotionType potion, int x, int y, @Nullable Color color) {

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyConfig.java
@@ -34,6 +34,16 @@ public interface MasteringMixologyConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "showStationTags",
+            name = "Station tags",
+            description = "Tag each finished potion (top-left) with the station it was processed at (Agitator/Retort/Alembic)",
+            position = 1
+    )
+    default boolean showStationTags() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "potionOrderSorting",
             name = "Order sorting",
             description = "Determines how potion orders are sorted in the interface",

--- a/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
+++ b/src/main/java/work/fking/masteringmixology/MasteringMixologyPlugin.java
@@ -4,6 +4,8 @@ import com.google.inject.Provides;
 import net.runelite.api.Client;
 import net.runelite.api.FontID;
 import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.Player;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.LocalPoint;
@@ -37,9 +39,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.awt.Color;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,6 +137,19 @@ public class MasteringMixologyPlugin extends Plugin {
     private PotionType agitatorPotionType;
     private PotionType retortPotionType;
 
+    // Tagging finished potions with the station they were processed at.  The finished
+    // item id is type-only, so the station is captured when a station-potion varbit
+    // returns to 0 (processing done) and matched to the finished potion that lands in
+    // the inventory the same tick.
+    // slot index -> modifier (station) for finished potions currently held.
+    private final Map<Integer, PotionModifier> taggedSlots = new HashMap<>();
+    // finishes awaiting an inventory match: each {finishedItemId, modifierOrdinal, tick}.
+    private final Deque<int[]> pendingTags = new ArrayDeque<>();
+
+    public PotionModifier stationTag(int slot) {
+        return taggedSlots.get(slot);
+    }
+
     private int previousAgitatorProgess;
     private int previousAlembicProgress;
 
@@ -185,6 +204,10 @@ public class MasteringMixologyPlugin extends Plugin {
     public void onGameStateChanged(GameStateChanged event) {
         if (event.getGameState() == GameState.LOGIN_SCREEN || event.getGameState() == GameState.HOPPING) {
             highlightedObjects.clear();
+            // Keep taggedSlots across a relog/hop — the inventory (and its slots) persist
+            // server-side, so the station tags stay valid; only the transient pending state
+            // is reset.  The onItemContainerChanged reconcile on login drops stale slots.
+            pendingTags.clear();
         }
     }
 
@@ -249,7 +272,16 @@ public class MasteringMixologyPlugin extends Plugin {
 
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event) {
-        if (!inLab || !config.highlightStations() || event.getContainerId() != InventoryID.INV) {
+        if (event.getContainerId() != InventoryID.INV) {
+            return;
+        }
+        // Only reconcile while logged in so a transient empty-inventory event around logout
+        // doesn't wipe the tags (they should survive the relog).
+        if (client.getGameState() == GameState.LOGGED_IN) {
+            updateStationTags(event.getItemContainer());
+        }
+
+        if (!inLab || !config.highlightStations()) {
             return;
         }
         // Do not update the highlight if there's a potion in a station
@@ -275,6 +307,65 @@ public class MasteringMixologyPlugin extends Plugin {
         }
     }
 
+    private void queueStationTag(PotionType type, PotionModifier modifier) {
+        if (type == null) {
+            return;
+        }
+        pendingTags.addLast(new int[]{type.modifiedItemId(), modifier.ordinal(), client.getTickCount()});
+        updateStationTags(client.getItemContainer(InventoryID.INV));
+    }
+
+    // Reconcile slot->station tags against the inventory: drop tags whose slot no longer
+    // holds a finished potion, then assign queued station finishes to the matching finished
+    // potion(s) that have appeared in the inventory.
+    private void updateStationTags(ItemContainer inventory) {
+        if (inventory == null) {
+            return;
+        }
+        Item[] items = inventory.getItems();
+
+        taggedSlots.keySet().removeIf(slot -> {
+            if (slot < 0 || slot >= items.length) {
+                return true;
+            }
+            var pt = PotionType.fromItemId(items[slot].getId());
+            return pt == null || pt.modifiedItemId() != items[slot].getId();
+        });
+
+        int now = client.getTickCount();
+        pendingTags.removeIf(e -> now - e[2] > 5);
+        if (pendingTags.isEmpty()) {
+            return;
+        }
+        for (int i = 0; i < items.length && !pendingTags.isEmpty(); i++) {
+            int id = items[i].getId();
+            var pt = PotionType.fromItemId(id);
+            if (pt == null || pt.modifiedItemId() != id || taggedSlots.containsKey(i)) {
+                continue;
+            }
+            PotionModifier modifier = popPendingForItem(id);
+            if (modifier != null) {
+                taggedSlots.put(i, modifier);
+            }
+        }
+    }
+
+    // Prefer an exact item-id match; if none and exactly one finish is queued, use it.
+    private PotionModifier popPendingForItem(int finishedItemId) {
+        for (Iterator<int[]> it = pendingTags.iterator(); it.hasNext(); ) {
+            int[] e = it.next();
+            if (e[0] == finishedItemId) {
+                it.remove();
+                return PotionModifier.values()[e[1]];
+            }
+        }
+        if (pendingTags.size() == 1) {
+            int[] e = pendingTags.pollFirst();
+            return PotionModifier.values()[e[1]];
+        }
+        return null;
+    }
+
     @Subscribe
     public void onVarbitChanged(VarbitChanged event) {
         var varbitId = event.getVarbitId();
@@ -294,6 +385,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 // Finished crystalising
                 unHighlightObject(AlchemyObject.ALEMBIC);
                 tryFulfillOrder(alembicPotionType, PotionModifier.CRYSTALISED);
+                queueStationTag(alembicPotionType, PotionModifier.CRYSTALISED);
                 tryHighlightNextStation();
                 LOGGER.debug("Finished crystalising {}", alembicPotionType);
                 alembicPotionType = null;
@@ -306,6 +398,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 // Finished homogenising
                 unHighlightObject(AlchemyObject.AGITATOR);
                 tryFulfillOrder(agitatorPotionType, PotionModifier.HOMOGENOUS);
+                queueStationTag(agitatorPotionType, PotionModifier.HOMOGENOUS);
                 tryHighlightNextStation();
                 LOGGER.debug("Finished homogenising {}", agitatorPotionType);
                 agitatorPotionType = null;
@@ -318,6 +411,7 @@ public class MasteringMixologyPlugin extends Plugin {
                 // Finished concentrating
                 unHighlightObject(AlchemyObject.RETORT);
                 tryFulfillOrder(retortPotionType, PotionModifier.CONCENTRATED);
+                queueStationTag(retortPotionType, PotionModifier.CONCENTRATED);
                 tryHighlightNextStation();
                 LOGGER.debug("Finished concentrating {}", retortPotionType);
                 retortPotionType = null;


### PR DESCRIPTION
# Add inventory station tags for finished potions

![Inventory station tags](https://raw.githubusercontent.com/JessePuente/mastering-mixology/pr-assets/docs/station-tags.png)

## What
Adds an optional overlay that tags each **finished** potion in the inventory with the
processing station it was made at — **Agi** / **Ret** / **Ale** (Agitator / Retort /
Alembic), colour-coded. The tag is drawn in the **top-left** of the item so it does not
overlap the existing recipe tag (which stays bottom-left). A new **"Station tags"** config
option toggles it.

## Why
Once you pre-process a batch of potions, the finished item looks identical regardless of
the station used — the modifier (Homogenised / Concentrated / Crystalised) isn't visible on
the item. It's easy to lose track of which finished potions are which when filling orders.
This surfaces it at a glance.

## How
Reuses the plugin's existing station-potion varbit tracking (the same signal already used to
fulfil orders): when a station's potion varbit returns to 0 the potion has finished with that
station's modifier, which is matched to the finished potion that appears in the inventory and
remembered per inventory slot. Tags are cleared when a slot no longer holds a finished potion,
and persist across logout / world-hop (the inventory and its slots are server-side).

## Notes
- New config item `showStationTags` ("Station tags") — **default off** (opt-in).
- `./gradlew build` (incl. `checkstyleMain`/`checkstyleTest`/`test`) passes.
- Station tags shown top-left, recipe tags bottom-left (see screenshot above).
